### PR TITLE
fix quickstart link in homepage

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -5,7 +5,7 @@ hero:
   tagline: Purpose-built log analytics UI for ClickHouse
   actions:
     - text: Quick Start
-      link: /docs/getting-started/quickstart
+      link: /getting-started/quickstart/
       icon: right-arrow
       variant: primary
     - text: Try Demo


### PR DESCRIPTION
from https://logchef.app/docs/getting-started/quickstart to https://logchef.app/getting-started/quickstart/