### PR TITLE
fix(docker): add missing API token config to docker-compose

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -134,6 +134,10 @@ configs:
       admin_emails = ["admin@logchef.internal"]
       session_duration = "24h"
       max_concurrent_sessions = 1
+      # Secret key for API token hashing (generate with: openssl rand -hex 32)
+      api_token_secret = "5679649c50fddda837449b77d9983ab5f8dba65878897e968a74e7061bf47677"
+      # Default API token expiration (empty for no expiration)
+      default_token_expiry = "2160h"  # 90 days = 90 * 24 = 2160 hours
 
       [logging]
       level = "debug"


### PR DESCRIPTION
Fixes container startup failure by adding api_token_secret and default_token_expiry to the docker-compose config.

Fixes #45