### PR TITLE
Add placeholder asset to satisfy go:embed build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,8 @@ DEVELOPMENT_GOALS.md
 *.db*
 .vscode/
 bin/
-cmd/server/ui/
+cmd/server/ui/*
+!cmd/server/ui/.placeholder
 frontend/stats.html
 
 # Docs

--- a/cmd/server/ui/.placeholder
+++ b/cmd/server/ui/.placeholder
@@ -1,0 +1,2 @@
+This placeholder file ensures that go:embed has at least one file to include.
+It can be safely removed once the frontend build assets are generated into this directory.


### PR DESCRIPTION
## Summary
- add a tracked placeholder file under cmd/server/ui so go:embed always has a file to include
- adjust .gitignore to continue ignoring generated frontend assets while keeping the placeholder

## Testing
- go test ./cmd/... *(fails: requires fetching Go module dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ee05d1b03c83209719063a6c08df93