### PR TITLE
Add alert history pruning to enforce retention limit

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -65,3 +65,11 @@ model = "gpt-4o"
 max_tokens = 1024
 # Temperature for generation (0.0-1.0, lower is more deterministic)
 temperature = 0.1
+
+# Alerting configuration
+[alerts]
+enabled = true
+evaluation_interval = "1m"
+default_lookback = "5m"
+notification_timeout = "5s"
+history_limit = 50

--- a/internal/alerts/manager.go
+++ b/internal/alerts/manager.go
@@ -1,0 +1,309 @@
+package alerts
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mr-karan/logchef/internal/clickhouse"
+	"github.com/mr-karan/logchef/internal/config"
+	"github.com/mr-karan/logchef/internal/sqlite"
+	"github.com/mr-karan/logchef/pkg/models"
+)
+
+// Options encapsulates the dependencies required to run the alerting manager.
+type Options struct {
+	Config     config.AlertsConfig
+	DB         *sqlite.DB
+	ClickHouse *clickhouse.Manager
+	Logger     *slog.Logger
+	Notifier   Notifier
+}
+
+// Manager coordinates alert evaluation and dispatches notifications when thresholds are met.
+type Manager struct {
+	cfg        config.AlertsConfig
+	db         *sqlite.DB
+	clickhouse *clickhouse.Manager
+	log        *slog.Logger
+	notifier   Notifier
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// NewManager constructs a new alert manager instance.
+func NewManager(opts Options) *Manager {
+	notifier := opts.Notifier
+	if notifier == nil {
+		notifier = NewDefaultNotifier(opts.Logger)
+	}
+	return &Manager{
+		cfg:        opts.Config,
+		db:         opts.DB,
+		clickhouse: opts.ClickHouse,
+		log:        opts.Logger.With("component", "alert_manager"),
+		notifier:   notifier,
+		stop:       make(chan struct{}),
+	}
+}
+
+// Start launches the evaluation loop. It is a no-op when alerting is disabled.
+func (m *Manager) Start(ctx context.Context) {
+	if !m.cfg.Enabled {
+		m.log.Info("alerting disabled; manager will not start")
+		return
+	}
+	interval := m.cfg.EvaluationInterval
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	m.log.Info("starting alert manager", "interval", interval)
+
+	m.wg.Add(1)
+	go func() {
+		defer m.wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+
+		// Run an initial evaluation so alerts fire soon after startup.
+		m.evaluateCycle(ctx)
+
+		for {
+			select {
+			case <-ticker.C:
+				m.evaluateCycle(ctx)
+			case <-m.stop:
+				m.log.Info("alert manager stopping")
+				return
+			case <-ctx.Done():
+				m.log.Info("alert manager context cancelled")
+				return
+			}
+		}
+	}()
+}
+
+// Stop signals the manager to stop evaluating alerts.
+func (m *Manager) Stop() {
+	close(m.stop)
+	m.wg.Wait()
+}
+
+func (m *Manager) evaluateCycle(ctx context.Context) {
+	alerts, err := m.db.ListActiveAlertsDue(ctx)
+	if err != nil {
+		m.log.Error("failed to fetch alerts for evaluation", "error", err)
+		return
+	}
+	if len(alerts) == 0 {
+		m.log.Debug("no alerts due for evaluation")
+		return
+	}
+
+	for _, alert := range alerts {
+		if err := m.evaluateAlert(ctx, alert); err != nil {
+			m.log.Error("alert evaluation failed", "alert_id", alert.ID, "error", err)
+		}
+	}
+}
+
+func (m *Manager) evaluateAlert(ctx context.Context, alert *models.Alert) error {
+	source, err := m.db.GetSource(ctx, alert.SourceID)
+	if err != nil {
+		return fmt.Errorf("failed to load source for alert %d: %w", alert.ID, err)
+	}
+
+	query, err := m.buildEvaluationQuery(alert, source)
+	if err != nil {
+		return err
+	}
+
+	client, err := m.clickhouse.GetConnection(alert.SourceID)
+	if err != nil {
+		return fmt.Errorf("failed to obtain ClickHouse connection: %w", err)
+	}
+
+	timeout := models.DefaultQueryTimeoutSeconds
+	result, err := client.QueryWithTimeout(ctx, query, &timeout)
+	if err != nil {
+		return fmt.Errorf("alert query failed: %w", err)
+	}
+
+	value, err := extractFirstNumeric(result)
+	if err != nil {
+		return fmt.Errorf("failed to extract alert result: %w", err)
+	}
+
+	triggered := compareThreshold(value, alert.ThresholdValue, alert.ThresholdOperator)
+	if triggered {
+		return m.handleTriggered(ctx, alert, value)
+	}
+	return m.handleResolved(ctx, alert, value)
+}
+
+func (m *Manager) handleTriggered(ctx context.Context, alert *models.Alert, value float64) error {
+	// Avoid duplicating history entries if the alert is already active.
+	_, err := m.db.GetLatestUnresolvedAlertHistory(ctx, alert.ID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		m.log.Warn("failed to check existing alert history", "alert_id", alert.ID, "error", err)
+	}
+	alreadyActive := false
+	if err == nil {
+		alreadyActive = true
+	} else if errors.Is(err, sql.ErrNoRows) {
+		history := &models.AlertHistoryEntry{
+			AlertID:   alert.ID,
+			Status:    models.AlertStatusTriggered,
+			ValueText: strconv.FormatFloat(value, 'f', 4, 64),
+			Channels:  alert.Channels,
+			Message:   fmt.Sprintf("alert %s triggered with value %.4f", alert.Name, value),
+		}
+		if err := m.db.InsertAlertHistory(ctx, history); err != nil {
+			m.log.Error("failed to insert alert history", "alert_id", alert.ID, "error", err)
+		} else if pruneErr := m.db.PruneAlertHistory(ctx, alert.ID, m.cfg.HistoryLimit); pruneErr != nil {
+			m.log.Warn("failed to prune alert history", "alert_id", alert.ID, "error", pruneErr)
+		}
+	}
+
+	if err := m.db.MarkAlertTriggered(ctx, alert.ID); err != nil {
+		m.log.Error("failed to mark alert triggered", "alert_id", alert.ID, "error", err)
+	}
+
+	if alreadyActive {
+		m.log.Debug("alert already active, suppressing duplicate notifications", "alert_id", alert.ID)
+		return nil
+	}
+
+	timeout := m.cfg.NotificationTimeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	for _, ch := range alert.Channels {
+		notifyCtx, cancel := context.WithTimeout(ctx, timeout)
+		go func(channel models.AlertChannel) {
+			defer cancel()
+			if notifyErr := m.notifier.Notify(notifyCtx, alert, channel, NotificationPayload{
+				Value:   value,
+				Message: fmt.Sprintf("Alert %s triggered", alert.Name),
+			}); notifyErr != nil {
+				m.log.Warn("notification failed", "alert_id", alert.ID, "channel", channel.Type, "target", channel.Target, "error", notifyErr)
+			}
+		}(ch)
+	}
+	return nil
+}
+
+func (m *Manager) handleResolved(ctx context.Context, alert *models.Alert, value float64) error {
+	if err := m.db.MarkAlertEvaluated(ctx, alert.ID); err != nil {
+		m.log.Error("failed to mark alert evaluated", "alert_id", alert.ID, "error", err)
+	}
+
+	entry, err := m.db.GetLatestUnresolvedAlertHistory(ctx, alert.ID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		return fmt.Errorf("failed to fetch unresolved alert history: %w", err)
+	}
+
+	message := fmt.Sprintf("alert %s resolved with value %.4f", alert.Name, value)
+	if err := m.db.ResolveAlertHistory(ctx, entry.ID, message); err != nil {
+		return fmt.Errorf("failed to resolve alert history: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) buildEvaluationQuery(alert *models.Alert, source *models.Source) (string, error) {
+	switch alert.QueryType {
+	case models.AlertQueryTypeSQL:
+		return alert.Query, nil
+	case models.AlertQueryTypeLogCondition:
+		lookback := alert.LookbackSeconds
+		if lookback <= 0 {
+			lookback = int(m.cfg.DefaultLookback.Seconds())
+		}
+		condition := strings.TrimSpace(alert.Query)
+		if condition == "" {
+			return "", fmt.Errorf("log condition alert requires a query filter")
+		}
+		tsField := source.MetaTSField
+		if tsField == "" {
+			return "", fmt.Errorf("source missing timestamp field for log condition alerts")
+		}
+		table := source.GetFullTableName()
+		return fmt.Sprintf("SELECT count(*) AS value FROM %s WHERE (%s) AND %s >= now() - INTERVAL %d SECOND", table, condition, tsField, lookback), nil
+	default:
+		return "", fmt.Errorf("unsupported alert query type %q", alert.QueryType)
+	}
+}
+
+func extractFirstNumeric(result *models.QueryResult) (float64, error) {
+	if result == nil || len(result.Logs) == 0 {
+		return 0, fmt.Errorf("query returned no rows")
+	}
+	row := result.Logs[0]
+	if len(result.Columns) == 0 {
+		return 0, fmt.Errorf("query returned no columns")
+	}
+	firstColumn := result.Columns[0].Name
+	rawValue, ok := row[firstColumn]
+	if !ok {
+		for _, v := range row {
+			rawValue = v
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return 0, fmt.Errorf("unable to locate numeric value in query result")
+	}
+	switch v := rawValue.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case uint64:
+		return float64(v), nil
+	case uint32:
+		return float64(v), nil
+	case string:
+		parsed, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, fmt.Errorf("unable to parse numeric value: %w", err)
+		}
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("unsupported result type %T", rawValue)
+	}
+}
+
+func compareThreshold(value, threshold float64, operator models.AlertThresholdOperator) bool {
+	switch operator {
+	case models.AlertThresholdGreaterThan:
+		return value > threshold
+	case models.AlertThresholdGreaterThanOrEqual:
+		return value >= threshold
+	case models.AlertThresholdLessThan:
+		return value < threshold
+	case models.AlertThresholdLessThanOrEqual:
+		return value <= threshold
+	case models.AlertThresholdEqual:
+		return math.Abs(value-threshold) < 1e-9
+	case models.AlertThresholdNotEqual:
+		return math.Abs(value-threshold) >= 1e-9
+	default:
+		return false
+	}
+}

--- a/internal/alerts/notifier.go
+++ b/internal/alerts/notifier.go
@@ -1,0 +1,81 @@
+package alerts
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/mr-karan/logchef/pkg/models"
+)
+
+// NotificationPayload captures the essential information passed to notifier implementations.
+type NotificationPayload struct {
+	Value   float64
+	Message string
+}
+
+// Notifier defines the contract for sending alert notifications.
+type Notifier interface {
+	Notify(ctx context.Context, alert *models.Alert, channel models.AlertChannel, payload NotificationPayload) error
+}
+
+// DefaultNotifier implements a simple multi-channel notifier using logging for email/slack
+// and HTTP POST requests for webhooks.
+type DefaultNotifier struct {
+	log        *slog.Logger
+	httpClient *http.Client
+}
+
+// NewDefaultNotifier returns a notifier that uses best-effort delivery for each channel type.
+func NewDefaultNotifier(log *slog.Logger) *DefaultNotifier {
+	client := &http.Client{Timeout: 5 * time.Second}
+	if log == nil {
+		log = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &DefaultNotifier{log: log.With("component", "alert_notifier"), httpClient: client}
+}
+
+// Notify dispatches the alert to the configured target.
+func (n *DefaultNotifier) Notify(ctx context.Context, alert *models.Alert, channel models.AlertChannel, payload NotificationPayload) error {
+	switch channel.Type {
+	case models.AlertChannelEmail:
+		n.log.Info("email notification", "alert_id", alert.ID, "target", channel.Target, "message", payload.Message, "value", payload.Value)
+		return nil
+	case models.AlertChannelSlack:
+		n.log.Info("slack notification", "alert_id", alert.ID, "target", channel.Target, "message", payload.Message, "value", payload.Value)
+		return nil
+	case models.AlertChannelWebhook:
+		body := map[string]any{
+			"alert_id": alert.ID,
+			"name":     alert.Name,
+			"severity": alert.Severity,
+			"value":    payload.Value,
+			"message":  payload.Message,
+		}
+		buf, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("failed to marshal webhook payload: %w", err)
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, channel.Target, bytes.NewReader(buf))
+		if err != nil {
+			return fmt.Errorf("failed to create webhook request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := n.httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("webhook request failed: %w", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			return fmt.Errorf("webhook returned status %d", resp.StatusCode)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported channel type %q", channel.Type)
+	}
+}

--- a/internal/core/alerts.go
+++ b/internal/core/alerts.go
@@ -1,0 +1,281 @@
+package core
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/mr-karan/logchef/internal/sqlite"
+	"github.com/mr-karan/logchef/pkg/models"
+)
+
+var (
+	// ErrAlertNotFound is returned when an alert rule cannot be located.
+	ErrAlertNotFound = errors.New("alert not found")
+	// ErrInvalidAlertConfiguration indicates the request payload failed validation.
+	ErrInvalidAlertConfiguration = errors.New("invalid alert configuration")
+)
+
+var validOperators = map[models.AlertThresholdOperator]struct{}{
+	models.AlertThresholdGreaterThan:        {},
+	models.AlertThresholdGreaterThanOrEqual: {},
+	models.AlertThresholdLessThan:           {},
+	models.AlertThresholdLessThanOrEqual:    {},
+	models.AlertThresholdEqual:              {},
+	models.AlertThresholdNotEqual:           {},
+}
+
+var validSeverities = map[models.AlertSeverity]struct{}{
+	models.AlertSeverityInfo:     {},
+	models.AlertSeverityWarning:  {},
+	models.AlertSeverityCritical: {},
+}
+
+var validQueryTypes = map[models.AlertQueryType]struct{}{
+	models.AlertQueryTypeSQL:          {},
+	models.AlertQueryTypeLogCondition: {},
+}
+
+var validChannelTypes = map[models.AlertChannelType]struct{}{
+	models.AlertChannelEmail:   {},
+	models.AlertChannelSlack:   {},
+	models.AlertChannelWebhook: {},
+}
+
+// validateAlertChannels ensures the provided notification configuration is supported.
+func validateAlertChannels(channels []models.AlertChannel) error {
+	if len(channels) == 0 {
+		return fmt.Errorf("at least one notification channel is required")
+	}
+	for idx, ch := range channels {
+		if strings.TrimSpace(ch.Target) == "" {
+			return fmt.Errorf("channel target is required (index %d)", idx)
+		}
+		if _, ok := validChannelTypes[ch.Type]; !ok {
+			return fmt.Errorf("unsupported channel type %q", ch.Type)
+		}
+	}
+	return nil
+}
+
+func validateAlertRequest(req *models.CreateAlertRequest) error {
+	if req.Name == "" {
+		return fmt.Errorf("name is required")
+	}
+	if _, ok := validQueryTypes[req.QueryType]; !ok {
+		return fmt.Errorf("invalid query_type %q", req.QueryType)
+	}
+	if strings.TrimSpace(req.Query) == "" {
+		return fmt.Errorf("query is required")
+	}
+	if _, ok := validOperators[req.ThresholdOperator]; !ok {
+		return fmt.Errorf("invalid threshold_operator %q", req.ThresholdOperator)
+	}
+	if req.FrequencySeconds <= 0 {
+		return fmt.Errorf("frequency_seconds must be greater than zero")
+	}
+	if req.LookbackSeconds <= 0 {
+		return fmt.Errorf("lookback_seconds must be greater than zero")
+	}
+	if _, ok := validSeverities[req.Severity]; !ok {
+		return fmt.Errorf("invalid severity %q", req.Severity)
+	}
+	if err := validateAlertChannels(req.Channels); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CreateAlert creates a new alert rule for the specified team and source.
+func CreateAlert(ctx context.Context, db *sqlite.DB, log *slog.Logger, teamID models.TeamID, sourceID models.SourceID, req *models.CreateAlertRequest) (*models.Alert, error) {
+	if req == nil {
+		return nil, ErrInvalidAlertConfiguration
+	}
+	if err := validateAlertRequest(req); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidAlertConfiguration, err)
+	}
+
+	alert := &models.Alert{
+		TeamID:            teamID,
+		SourceID:          sourceID,
+		Name:              strings.TrimSpace(req.Name),
+		Description:       strings.TrimSpace(req.Description),
+		QueryType:         req.QueryType,
+		Query:             strings.TrimSpace(req.Query),
+		LookbackSeconds:   req.LookbackSeconds,
+		ThresholdOperator: req.ThresholdOperator,
+		ThresholdValue:    req.ThresholdValue,
+		FrequencySeconds:  req.FrequencySeconds,
+		Severity:          req.Severity,
+		Channels:          req.Channels,
+		IsActive:          req.IsActive,
+	}
+
+	if err := db.CreateAlert(ctx, alert); err != nil {
+		log.Error("failed to create alert", "team_id", teamID, "source_id", sourceID, "error", err)
+		return nil, fmt.Errorf("failed to create alert: %w", err)
+	}
+	log.Info("alert created", "alert_id", alert.ID, "team_id", teamID, "source_id", sourceID)
+	return alert, nil
+}
+
+// GetAlert retrieves a single alert by ID.
+func GetAlert(ctx context.Context, db *sqlite.DB, log *slog.Logger, alertID models.AlertID) (*models.Alert, error) {
+	alert, err := db.GetAlert(ctx, alertID)
+	if err != nil {
+		if errors.Is(err, sqlite.ErrNotFound) || errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrAlertNotFound
+		}
+		log.Error("failed to get alert", "alert_id", alertID, "error", err)
+		return nil, fmt.Errorf("failed to get alert: %w", err)
+	}
+	return alert, nil
+}
+
+// UpdateAlert updates an existing alert rule.
+func UpdateAlert(ctx context.Context, db *sqlite.DB, log *slog.Logger, teamID models.TeamID, sourceID models.SourceID, alertID models.AlertID, req *models.UpdateAlertRequest) (*models.Alert, error) {
+	if req == nil {
+		return nil, ErrInvalidAlertConfiguration
+	}
+
+	existing, err := db.GetAlertForTeamSource(ctx, teamID, sourceID, alertID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return nil, ErrAlertNotFound
+		}
+		log.Error("failed to load alert for update", "alert_id", alertID, "error", err)
+		return nil, fmt.Errorf("failed to load alert: %w", err)
+	}
+
+	if req.Name != nil {
+		existing.Name = strings.TrimSpace(*req.Name)
+	}
+	if req.Description != nil {
+		existing.Description = strings.TrimSpace(*req.Description)
+	}
+	if req.QueryType != nil {
+		if _, ok := validQueryTypes[*req.QueryType]; !ok {
+			return nil, fmt.Errorf("%w: invalid query_type %q", ErrInvalidAlertConfiguration, *req.QueryType)
+		}
+		existing.QueryType = *req.QueryType
+	}
+	if req.Query != nil {
+		if strings.TrimSpace(*req.Query) == "" {
+			return nil, fmt.Errorf("%w: query is required", ErrInvalidAlertConfiguration)
+		}
+		existing.Query = strings.TrimSpace(*req.Query)
+	}
+	if req.LookbackSeconds != nil {
+		if *req.LookbackSeconds <= 0 {
+			return nil, fmt.Errorf("%w: lookback_seconds must be greater than zero", ErrInvalidAlertConfiguration)
+		}
+		existing.LookbackSeconds = *req.LookbackSeconds
+	}
+	if req.ThresholdOperator != nil {
+		if _, ok := validOperators[*req.ThresholdOperator]; !ok {
+			return nil, fmt.Errorf("%w: invalid threshold_operator %q", ErrInvalidAlertConfiguration, *req.ThresholdOperator)
+		}
+		existing.ThresholdOperator = *req.ThresholdOperator
+	}
+	if req.ThresholdValue != nil {
+		existing.ThresholdValue = *req.ThresholdValue
+	}
+	if req.FrequencySeconds != nil {
+		if *req.FrequencySeconds <= 0 {
+			return nil, fmt.Errorf("%w: frequency_seconds must be greater than zero", ErrInvalidAlertConfiguration)
+		}
+		existing.FrequencySeconds = *req.FrequencySeconds
+	}
+	if req.Severity != nil {
+		if _, ok := validSeverities[*req.Severity]; !ok {
+			return nil, fmt.Errorf("%w: invalid severity %q", ErrInvalidAlertConfiguration, *req.Severity)
+		}
+		existing.Severity = *req.Severity
+	}
+	if req.Channels != nil {
+		if err := validateAlertChannels(*req.Channels); err != nil {
+			return nil, fmt.Errorf("%w: %s", ErrInvalidAlertConfiguration, err)
+		}
+		existing.Channels = *req.Channels
+	}
+	if req.IsActive != nil {
+		existing.IsActive = *req.IsActive
+	}
+
+	if err := db.UpdateAlert(ctx, existing); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return nil, ErrAlertNotFound
+		}
+		log.Error("failed to update alert", "alert_id", alertID, "error", err)
+		return nil, fmt.Errorf("failed to update alert: %w", err)
+	}
+
+	updated, err := db.GetAlertForTeamSource(ctx, teamID, sourceID, alertID)
+	if err != nil {
+		log.Warn("alert updated but fetching updated record failed", "alert_id", alertID, "error", err)
+		return existing, nil
+	}
+	return updated, nil
+}
+
+// DeleteAlert removes an alert rule.
+func DeleteAlert(ctx context.Context, db *sqlite.DB, log *slog.Logger, teamID models.TeamID, sourceID models.SourceID, alertID models.AlertID) error {
+	if _, err := db.GetAlertForTeamSource(ctx, teamID, sourceID, alertID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return ErrAlertNotFound
+		}
+		return fmt.Errorf("failed to validate alert ownership: %w", err)
+	}
+	if err := db.DeleteAlert(ctx, alertID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return ErrAlertNotFound
+		}
+		log.Error("failed to delete alert", "alert_id", alertID, "error", err)
+		return fmt.Errorf("failed to delete alert: %w", err)
+	}
+	log.Info("alert deleted", "alert_id", alertID, "team_id", teamID, "source_id", sourceID)
+	return nil
+}
+
+// ListAlertsByTeamSource returns all alerts for a team/source pair.
+func ListAlertsByTeamSource(ctx context.Context, db *sqlite.DB, teamID models.TeamID, sourceID models.SourceID) ([]*models.Alert, error) {
+	alerts, err := db.ListAlertsByTeamAndSource(ctx, teamID, sourceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list alerts: %w", err)
+	}
+	return alerts, nil
+}
+
+// ListAlertHistory retrieves a limited set of alert history entries.
+func ListAlertHistory(ctx context.Context, db *sqlite.DB, alertID models.AlertID, limit int) ([]*models.AlertHistoryEntry, error) {
+	history, err := db.ListAlertHistory(ctx, alertID, limit)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return []*models.AlertHistoryEntry{}, nil
+		}
+		return nil, fmt.Errorf("failed to list alert history: %w", err)
+	}
+	return history, nil
+}
+
+// ResolveAlert manually resolves the most recent triggered history entry.
+func ResolveAlert(ctx context.Context, db *sqlite.DB, log *slog.Logger, alertID models.AlertID, message string) error {
+	entry, err := db.GetLatestUnresolvedAlertHistory(ctx, alertID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return ErrAlertNotFound
+		}
+		return fmt.Errorf("failed to find unresolved alert history: %w", err)
+	}
+	if err := db.ResolveAlertHistory(ctx, entry.ID, message); err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return ErrAlertNotFound
+		}
+		return fmt.Errorf("failed to resolve alert history: %w", err)
+	}
+	log.Info("alert history resolved", "alert_id", alertID, "history_id", entry.ID)
+	return nil
+}

--- a/internal/core/users.go
+++ b/internal/core/users.go
@@ -324,7 +324,7 @@ func InitAdminUsers(ctx context.Context, db *sqlite.DB, log *slog.Logger, adminE
 				if createErr != nil {
 					errMsg := fmt.Sprintf("failed to create admin user %s: %v", email, createErr)
 					log.Error(errMsg)
-					setupErrors = append(setupErrors, fmt.Errorf(errMsg))
+					setupErrors = append(setupErrors, errors.New(errMsg))
 				} else {
 					log.Info("created new admin user successfully", "email", email, "user_id", newUser.ID)
 				}
@@ -334,7 +334,7 @@ func InitAdminUsers(ctx context.Context, db *sqlite.DB, log *slog.Logger, adminE
 			// If it's a different error (not "not found"), log and continue
 			errMsg := fmt.Sprintf("failed to check existing admin user %s: %v", email, err)
 			log.Error(errMsg)
-			setupErrors = append(setupErrors, fmt.Errorf(errMsg))
+			setupErrors = append(setupErrors, errors.New(errMsg))
 			continue // Try next email
 		}
 
@@ -355,7 +355,7 @@ func InitAdminUsers(ctx context.Context, db *sqlite.DB, log *slog.Logger, adminE
 				if err := db.UpdateUser(ctx, existing); err != nil {
 					errMsg := fmt.Sprintf("failed to update admin user %s: %v", email, err)
 					log.Error(errMsg)
-					setupErrors = append(setupErrors, fmt.Errorf(errMsg))
+					setupErrors = append(setupErrors, errors.New(errMsg))
 				} else {
 					log.Info("updated existing user to active admin", "email", email, "user_id", existing.ID)
 				}
@@ -370,7 +370,7 @@ func InitAdminUsers(ctx context.Context, db *sqlite.DB, log *slog.Logger, adminE
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to count admin users after initialization: %v", err)
 		log.Error(errMsg)
-		setupErrors = append(setupErrors, fmt.Errorf(errMsg))
+		setupErrors = append(setupErrors, errors.New(errMsg))
 	} else if count == 0 {
 		errMsg := "initialization finished, but no active admin users found in the database"
 		log.Error(errMsg)

--- a/internal/server/alert_handlers.go
+++ b/internal/server/alert_handlers.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/mr-karan/logchef/internal/core"
+	"github.com/mr-karan/logchef/internal/sqlite"
+	"github.com/mr-karan/logchef/pkg/models"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func (s *Server) handleListAlerts(c *fiber.Ctx) error {
+	teamID, sourceID, err := s.parseTeamAndSourceIDs(c)
+	if err != nil {
+		return err
+	}
+
+	alerts, err := core.ListAlertsByTeamSource(c.Context(), s.sqlite, teamID, sourceID)
+	if err != nil {
+		s.log.Error("failed to list alerts", "team_id", teamID, "source_id", sourceID, "error", err)
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to list alerts", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusOK, alerts)
+}
+
+func (s *Server) handleCreateAlert(c *fiber.Ctx) error {
+	teamID, sourceID, err := s.parseTeamAndSourceIDs(c)
+	if err != nil {
+		return err
+	}
+
+	var req models.CreateAlertRequest
+	if err := c.BodyParser(&req); err != nil {
+		return SendErrorWithType(c, fiber.StatusBadRequest, "Invalid request body", models.ValidationErrorType)
+	}
+
+	alert, err := core.CreateAlert(c.Context(), s.sqlite, s.log, teamID, sourceID, &req)
+	if err != nil {
+		if errors.Is(err, core.ErrInvalidAlertConfiguration) {
+			return SendErrorWithType(c, fiber.StatusBadRequest, err.Error(), models.ValidationErrorType)
+		}
+		s.log.Error("failed to create alert", "team_id", teamID, "source_id", sourceID, "error", err)
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to create alert", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusCreated, alert)
+}
+
+func (s *Server) handleGetAlert(c *fiber.Ctx) error {
+	teamID, sourceID, alertID, err := s.parseAlertIdentifiers(c)
+	if err != nil {
+		return err
+	}
+
+	alert, err := s.sqlite.GetAlertForTeamSource(c.Context(), teamID, sourceID, alertID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) || errors.Is(err, sqlite.ErrNotFound) {
+			return SendErrorWithType(c, fiber.StatusNotFound, "Alert not found", models.NotFoundErrorType)
+		}
+		s.log.Error("failed to get alert", "alert_id", alertID, "error", err)
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to retrieve alert", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusOK, alert)
+}
+
+func (s *Server) handleUpdateAlert(c *fiber.Ctx) error {
+	teamID, sourceID, alertID, err := s.parseAlertIdentifiers(c)
+	if err != nil {
+		return err
+	}
+
+	var req models.UpdateAlertRequest
+	if err := c.BodyParser(&req); err != nil {
+		return SendErrorWithType(c, fiber.StatusBadRequest, "Invalid request body", models.ValidationErrorType)
+	}
+
+	updated, err := core.UpdateAlert(c.Context(), s.sqlite, s.log, teamID, sourceID, alertID, &req)
+	if err != nil {
+		switch {
+		case errors.Is(err, core.ErrInvalidAlertConfiguration):
+			return SendErrorWithType(c, fiber.StatusBadRequest, err.Error(), models.ValidationErrorType)
+		case errors.Is(err, core.ErrAlertNotFound):
+			return SendErrorWithType(c, fiber.StatusNotFound, "Alert not found", models.NotFoundErrorType)
+		default:
+			s.log.Error("failed to update alert", "alert_id", alertID, "error", err)
+			return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to update alert", models.GeneralErrorType)
+		}
+	}
+	return SendSuccess(c, fiber.StatusOK, updated)
+}
+
+func (s *Server) handleDeleteAlert(c *fiber.Ctx) error {
+	teamID, sourceID, alertID, err := s.parseAlertIdentifiers(c)
+	if err != nil {
+		return err
+	}
+
+	if err := core.DeleteAlert(c.Context(), s.sqlite, s.log, teamID, sourceID, alertID); err != nil {
+		if errors.Is(err, core.ErrAlertNotFound) {
+			return SendErrorWithType(c, fiber.StatusNotFound, "Alert not found", models.NotFoundErrorType)
+		}
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to delete alert", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusOK, fiber.Map{"message": "Alert deleted"})
+}
+
+func (s *Server) handleResolveAlert(c *fiber.Ctx) error {
+	_, _, alertID, err := s.parseAlertIdentifiers(c)
+	if err != nil {
+		return err
+	}
+
+	var req models.ResolveAlertRequest
+	if err := c.BodyParser(&req); err != nil {
+		return SendErrorWithType(c, fiber.StatusBadRequest, "Invalid request body", models.ValidationErrorType)
+	}
+
+	if err := core.ResolveAlert(c.Context(), s.sqlite, s.log, alertID, strings.TrimSpace(req.Message)); err != nil {
+		if errors.Is(err, core.ErrAlertNotFound) {
+			return SendErrorWithType(c, fiber.StatusNotFound, "Alert is not active", models.NotFoundErrorType)
+		}
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to resolve alert", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusOK, fiber.Map{"message": "Alert resolved"})
+}
+
+func (s *Server) handleListAlertHistory(c *fiber.Ctx) error {
+	_, _, alertID, err := s.parseAlertIdentifiers(c)
+	if err != nil {
+		return err
+	}
+
+	limit := s.config.Alerts.HistoryLimit
+	if limit <= 0 {
+		limit = models.DefaultAlertHistoryLimit
+	}
+	if limitStr := c.Query("limit"); limitStr != "" {
+		if parsed, err := strconv.Atoi(limitStr); err == nil && parsed > 0 {
+			if parsed < limit {
+				limit = parsed
+			}
+		}
+	}
+
+	history, err := core.ListAlertHistory(c.Context(), s.sqlite, alertID, limit)
+	if err != nil {
+		s.log.Error("failed to list alert history", "alert_id", alertID, "error", err)
+		return SendErrorWithType(c, fiber.StatusInternalServerError, "Failed to list alert history", models.GeneralErrorType)
+	}
+	return SendSuccess(c, fiber.StatusOK, history)
+}
+
+func (s *Server) parseTeamAndSourceIDs(c *fiber.Ctx) (models.TeamID, models.SourceID, error) {
+	teamIDStr := c.Params("teamID")
+	sourceIDStr := c.Params("sourceID")
+
+	teamID, err := core.ParseTeamID(teamIDStr)
+	if err != nil {
+		return 0, 0, SendErrorWithType(c, fiber.StatusBadRequest, "Invalid team_id parameter", models.ValidationErrorType)
+	}
+	sourceID, err := core.ParseSourceID(sourceIDStr)
+	if err != nil {
+		return 0, 0, SendErrorWithType(c, fiber.StatusBadRequest, "Invalid source_id parameter", models.ValidationErrorType)
+	}
+	return teamID, sourceID, nil
+}
+
+func (s *Server) parseAlertIdentifiers(c *fiber.Ctx) (models.TeamID, models.SourceID, models.AlertID, error) {
+	teamID, sourceID, err := s.parseTeamAndSourceIDs(c)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	alertIDStr := c.Params("alertID")
+	if alertIDStr == "" {
+		return 0, 0, 0, SendErrorWithType(c, fiber.StatusBadRequest, "Alert ID is required", models.ValidationErrorType)
+	}
+	parsedID, err := strconv.ParseInt(alertIDStr, 10, 64)
+	if err != nil {
+		return 0, 0, 0, SendErrorWithType(c, fiber.StatusBadRequest, "Invalid alert ID", models.ValidationErrorType)
+	}
+	return teamID, sourceID, models.AlertID(parsedID), nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -93,7 +93,7 @@ func New(opts ServerOptions) *Server {
 	app.Use(compress.New(compress.Config{
 		Level: compress.LevelBestSpeed, // Prioritize speed over maximum compression
 	})) // Compress responses
-	
+
 	// Add metrics middleware
 	app.Use(metrics.Middleware())
 
@@ -120,7 +120,7 @@ func New(opts ServerOptions) *Server {
 func (s *Server) setupRoutes() {
 	// Swagger documentation route
 	s.app.Get("/swagger/*", swagger.HandlerDefault)
-	
+
 	// Metrics endpoint
 	s.app.Get("/metrics", metrics.MetricsHandler())
 
@@ -222,6 +222,17 @@ func (s *Server) setupRoutes() {
 			collections.Post("/", s.requireCollectionManagement, s.handleCreateTeamSourceCollection)
 			collections.Put("/:collectionID", s.requireCollectionManagement, s.handleUpdateTeamSourceCollection)
 			collections.Delete("/:collectionID", s.requireCollectionManagement, s.handleDeleteTeamSourceCollection)
+		}
+
+		alerts := teamSourceOps.Group("/alerts")
+		{
+			alerts.Get("/", s.handleListAlerts)
+			alerts.Get("/:alertID", s.handleGetAlert)
+			alerts.Get("/:alertID/history", s.handleListAlertHistory)
+			alerts.Post("/", s.requireTeamAdminOrGlobalAdmin, s.handleCreateAlert)
+			alerts.Put("/:alertID", s.requireTeamAdminOrGlobalAdmin, s.handleUpdateAlert)
+			alerts.Delete("/:alertID", s.requireTeamAdminOrGlobalAdmin, s.handleDeleteAlert)
+			alerts.Post("/:alertID/resolve", s.requireTeamAdminOrGlobalAdmin, s.handleResolveAlert)
 		}
 	}
 

--- a/internal/sqlite/alerts.go
+++ b/internal/sqlite/alerts.go
@@ -1,0 +1,505 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/mr-karan/logchef/pkg/models"
+)
+
+const (
+	insertAlertQuery = `INSERT INTO alerts (
+    team_id,
+    source_id,
+    name,
+    description,
+    query_type,
+    query,
+    lookback_seconds,
+    threshold_operator,
+    threshold_value,
+    frequency_seconds,
+    severity,
+    channels,
+    is_active
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, created_at, updated_at, last_evaluated_at, last_triggered_at`
+
+	selectAlertBase = `SELECT
+    id,
+    team_id,
+    source_id,
+    name,
+    description,
+    query_type,
+    query,
+    lookback_seconds,
+    threshold_operator,
+    threshold_value,
+    frequency_seconds,
+    severity,
+    channels,
+    is_active,
+    last_evaluated_at,
+    last_triggered_at,
+    created_at,
+    updated_at
+FROM alerts`
+
+	listActiveAlertsDueQuery = selectAlertBase + `
+WHERE is_active = 1
+  AND (
+        last_evaluated_at IS NULL
+        OR last_evaluated_at <= datetime('now', '-' || frequency_seconds || ' seconds')
+      )`
+
+	updateAlertEvaluatedQuery = `UPDATE alerts
+SET last_evaluated_at = datetime('now'),
+    updated_at = datetime('now')
+WHERE id = ?`
+
+	updateAlertTriggeredQuery = `UPDATE alerts
+SET last_triggered_at = datetime('now'),
+    last_evaluated_at = datetime('now'),
+    updated_at = datetime('now')
+WHERE id = ?`
+
+	updateAlertQuery = `UPDATE alerts
+SET name = ?,
+    description = ?,
+    query_type = ?,
+    query = ?,
+    lookback_seconds = ?,
+    threshold_operator = ?,
+    threshold_value = ?,
+    frequency_seconds = ?,
+    severity = ?,
+    channels = ?,
+    is_active = ?,
+    updated_at = datetime('now')
+WHERE id = ?`
+
+	deleteAlertQuery = `DELETE FROM alerts WHERE id = ?`
+
+	insertAlertHistoryQuery = `INSERT INTO alert_history (
+    alert_id,
+    status,
+    value_text,
+    channels,
+    message
+) VALUES (?, ?, ?, ?, ?)
+RETURNING id, triggered_at, resolved_at, created_at`
+
+	selectAlertHistoryBase = `SELECT
+    id,
+    alert_id,
+    status,
+    triggered_at,
+    resolved_at,
+    value_text,
+    channels,
+    message,
+    created_at
+FROM alert_history`
+
+	getLatestUnresolvedHistoryQuery = selectAlertHistoryBase + `
+WHERE alert_id = ? AND status = 'triggered'
+ORDER BY triggered_at DESC
+LIMIT 1`
+
+	resolveAlertHistoryQuery = `UPDATE alert_history
+SET status = 'resolved',
+    resolved_at = datetime('now'),
+    message = ?
+WHERE id = ?`
+
+	pruneAlertHistoryQuery = `WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (ORDER BY triggered_at DESC, id DESC) AS rn
+    FROM alert_history
+    WHERE alert_id = ?
+)
+DELETE FROM alert_history
+WHERE alert_id = ?
+  AND id IN (
+    SELECT id FROM ranked WHERE rn > ?
+ )`
+)
+
+// CreateAlert inserts a new alert definition for a team/source pair.
+func (db *DB) CreateAlert(ctx context.Context, alert *models.Alert) error {
+	if alert == nil {
+		return fmt.Errorf("alert payload is required")
+	}
+
+	channelsJSON, err := json.Marshal(alert.Channels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alert channels: %w", err)
+	}
+
+	row := db.db.QueryRowContext(ctx, insertAlertQuery,
+		int64(alert.TeamID),
+		int64(alert.SourceID),
+		alert.Name,
+		nullableString(alert.Description),
+		string(alert.QueryType),
+		alert.Query,
+		alert.LookbackSeconds,
+		string(alert.ThresholdOperator),
+		alert.ThresholdValue,
+		alert.FrequencySeconds,
+		string(alert.Severity),
+		string(channelsJSON),
+		boolToInt(alert.IsActive),
+	)
+
+	var (
+		id              int64
+		createdAt       time.Time
+		updatedAt       time.Time
+		lastEvaluatedAt sql.NullTime
+		lastTriggeredAt sql.NullTime
+	)
+
+	if err := row.Scan(&id, &createdAt, &updatedAt, &lastEvaluatedAt, &lastTriggeredAt); err != nil {
+		return fmt.Errorf("failed to insert alert: %w", err)
+	}
+
+	alert.ID = models.AlertID(id)
+	alert.CreatedAt = createdAt
+	alert.UpdatedAt = updatedAt
+	if lastEvaluatedAt.Valid {
+		alert.LastEvaluatedAt = &lastEvaluatedAt.Time
+	}
+	if lastTriggeredAt.Valid {
+		alert.LastTriggeredAt = &lastTriggeredAt.Time
+	}
+	return nil
+}
+
+// UpdateAlert persists changes to an existing alert definition.
+func (db *DB) UpdateAlert(ctx context.Context, alert *models.Alert) error {
+	if alert == nil {
+		return fmt.Errorf("alert payload is required")
+	}
+
+	channelsJSON, err := json.Marshal(alert.Channels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal alert channels: %w", err)
+	}
+
+	res, err := db.db.ExecContext(ctx, updateAlertQuery,
+		alert.Name,
+		nullableString(alert.Description),
+		string(alert.QueryType),
+		alert.Query,
+		alert.LookbackSeconds,
+		string(alert.ThresholdOperator),
+		alert.ThresholdValue,
+		alert.FrequencySeconds,
+		string(alert.Severity),
+		string(channelsJSON),
+		boolToInt(alert.IsActive),
+		int64(alert.ID),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update alert: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// GetAlert retrieves an alert by its identifier.
+func (db *DB) GetAlert(ctx context.Context, alertID models.AlertID) (*models.Alert, error) {
+	query := selectAlertBase + " WHERE id = ?"
+	row := db.db.QueryRowContext(ctx, query, int64(alertID))
+	return scanAlert(row)
+}
+
+// GetAlertForTeamSource ensures the alert belongs to the requested team and source.
+func (db *DB) GetAlertForTeamSource(ctx context.Context, teamID models.TeamID, sourceID models.SourceID, alertID models.AlertID) (*models.Alert, error) {
+	query := selectAlertBase + " WHERE id = ? AND team_id = ? AND source_id = ?"
+	row := db.db.QueryRowContext(ctx, query, int64(alertID), int64(teamID), int64(sourceID))
+	return scanAlert(row)
+}
+
+// ListAlertsByTeamAndSource fetches all alerts scoped to a specific team and source.
+func (db *DB) ListAlertsByTeamAndSource(ctx context.Context, teamID models.TeamID, sourceID models.SourceID) ([]*models.Alert, error) {
+	query := selectAlertBase + " WHERE team_id = ? AND source_id = ? ORDER BY created_at DESC"
+	rows, err := db.db.QueryContext(ctx, query, int64(teamID), int64(sourceID))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list alerts: %w", err)
+	}
+	defer rows.Close()
+
+	var alerts []*models.Alert
+	for rows.Next() {
+		alert, err := scanAlert(rows)
+		if err != nil {
+			return nil, err
+		}
+		alerts = append(alerts, alert)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating alerts: %w", err)
+	}
+	return alerts, nil
+}
+
+// DeleteAlert removes an alert definition from the database.
+func (db *DB) DeleteAlert(ctx context.Context, alertID models.AlertID) error {
+	res, err := db.db.ExecContext(ctx, deleteAlertQuery, int64(alertID))
+	if err != nil {
+		return fmt.Errorf("failed to delete alert: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// ListActiveAlertsDue returns alerts that need to be evaluated.
+func (db *DB) ListActiveAlertsDue(ctx context.Context) ([]*models.Alert, error) {
+	rows, err := db.db.QueryContext(ctx, listActiveAlertsDueQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch due alerts: %w", err)
+	}
+	defer rows.Close()
+
+	var alerts []*models.Alert
+	for rows.Next() {
+		alert, err := scanAlert(rows)
+		if err != nil {
+			return nil, err
+		}
+		alerts = append(alerts, alert)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating due alerts: %w", err)
+	}
+	return alerts, nil
+}
+
+// MarkAlertEvaluated updates the bookkeeping fields when an alert evaluation completes without triggering.
+func (db *DB) MarkAlertEvaluated(ctx context.Context, alertID models.AlertID) error {
+	if _, err := db.db.ExecContext(ctx, updateAlertEvaluatedQuery, int64(alertID)); err != nil {
+		return fmt.Errorf("failed to mark alert evaluated: %w", err)
+	}
+	return nil
+}
+
+// MarkAlertTriggered updates the bookkeeping fields when an alert triggers.
+func (db *DB) MarkAlertTriggered(ctx context.Context, alertID models.AlertID) error {
+	if _, err := db.db.ExecContext(ctx, updateAlertTriggeredQuery, int64(alertID)); err != nil {
+		return fmt.Errorf("failed to mark alert triggered: %w", err)
+	}
+	return nil
+}
+
+// InsertAlertHistory creates a history entry for an alert trigger or resolution event.
+func (db *DB) InsertAlertHistory(ctx context.Context, entry *models.AlertHistoryEntry) error {
+	if entry == nil {
+		return fmt.Errorf("history entry is required")
+	}
+	channelsJSON, err := json.Marshal(entry.Channels)
+	if err != nil {
+		return fmt.Errorf("failed to marshal history channels: %w", err)
+	}
+
+	row := db.db.QueryRowContext(ctx, insertAlertHistoryQuery,
+		entry.AlertID,
+		string(entry.Status),
+		entry.ValueText,
+		string(channelsJSON),
+		nullableString(entry.Message),
+	)
+
+	var (
+		id          int64
+		triggeredAt time.Time
+		resolvedAt  sql.NullTime
+		createdAt   time.Time
+	)
+	if err := row.Scan(&id, &triggeredAt, &resolvedAt, &createdAt); err != nil {
+		return fmt.Errorf("failed to insert alert history: %w", err)
+	}
+	entry.ID = id
+	entry.TriggeredAt = triggeredAt
+	entry.CreatedAt = createdAt
+	if resolvedAt.Valid {
+		entry.ResolvedAt = &resolvedAt.Time
+	}
+	return nil
+}
+
+// ResolveAlertHistory marks a previously triggered history entry as resolved.
+func (db *DB) ResolveAlertHistory(ctx context.Context, historyID int64, message string) error {
+	res, err := db.db.ExecContext(ctx, resolveAlertHistoryQuery, nullableString(message), historyID)
+	if err != nil {
+		return fmt.Errorf("failed to resolve alert history: %w", err)
+	}
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		return sql.ErrNoRows
+	}
+	return nil
+}
+
+// PruneAlertHistory removes older history entries beyond the configured limit.
+func (db *DB) PruneAlertHistory(ctx context.Context, alertID models.AlertID, limit int) error {
+	if limit <= 0 {
+		limit = models.DefaultAlertHistoryLimit
+	}
+
+	if _, err := db.db.ExecContext(ctx, pruneAlertHistoryQuery, int64(alertID), int64(alertID), limit); err != nil {
+		return fmt.Errorf("failed to prune alert history: %w", err)
+	}
+	return nil
+}
+
+// GetLatestUnresolvedAlertHistory fetches the most recent trigger entry that has not been resolved.
+func (db *DB) GetLatestUnresolvedAlertHistory(ctx context.Context, alertID models.AlertID) (*models.AlertHistoryEntry, error) {
+	row := db.db.QueryRowContext(ctx, getLatestUnresolvedHistoryQuery, alertID)
+	return scanAlertHistory(row)
+}
+
+// ListAlertHistory returns the most recent history entries for an alert.
+func (db *DB) ListAlertHistory(ctx context.Context, alertID models.AlertID, limit int) ([]*models.AlertHistoryEntry, error) {
+	if limit <= 0 {
+		limit = models.DefaultAlertHistoryLimit
+	}
+	query := selectAlertHistoryBase + " WHERE alert_id = ? ORDER BY triggered_at DESC LIMIT ?"
+	rows, err := db.db.QueryContext(ctx, query, alertID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list alert history: %w", err)
+	}
+	defer rows.Close()
+
+	var history []*models.AlertHistoryEntry
+	for rows.Next() {
+		entry, err := scanAlertHistory(rows)
+		if err != nil {
+			return nil, err
+		}
+		history = append(history, entry)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating alert history: %w", err)
+	}
+	return history, nil
+}
+
+func scanAlert(scanner interface{ Scan(dest ...any) error }) (*models.Alert, error) {
+	var (
+		id                int64
+		teamID            int64
+		sourceID          int64
+		name              string
+		description       sql.NullString
+		queryType         string
+		query             string
+		lookbackSeconds   int
+		thresholdOperator string
+		thresholdValue    float64
+		frequencySeconds  int
+		severity          string
+		channelsJSON      string
+		isActive          int64
+		lastEvaluatedAt   sql.NullTime
+		lastTriggeredAt   sql.NullTime
+		createdAt         time.Time
+		updatedAt         time.Time
+	)
+	if err := scanner.Scan(&id, &teamID, &sourceID, &name, &description, &queryType, &query, &lookbackSeconds, &thresholdOperator, &thresholdValue, &frequencySeconds, &severity, &channelsJSON, &isActive, &lastEvaluatedAt, &lastTriggeredAt, &createdAt, &updatedAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan alert: %w", err)
+	}
+
+	var channels []models.AlertChannel
+	if channelsJSON != "" {
+		if err := json.Unmarshal([]byte(channelsJSON), &channels); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal alert channels: %w", err)
+		}
+	}
+
+	alert := &models.Alert{
+		ID:                models.AlertID(id),
+		TeamID:            models.TeamID(teamID),
+		SourceID:          models.SourceID(sourceID),
+		Name:              name,
+		Description:       description.String,
+		QueryType:         models.AlertQueryType(queryType),
+		Query:             query,
+		LookbackSeconds:   lookbackSeconds,
+		ThresholdOperator: models.AlertThresholdOperator(thresholdOperator),
+		ThresholdValue:    thresholdValue,
+		FrequencySeconds:  frequencySeconds,
+		Severity:          models.AlertSeverity(severity),
+		Channels:          channels,
+		IsActive:          isActive == 1,
+		CreatedAt:         createdAt,
+		UpdatedAt:         updatedAt,
+	}
+	if lastEvaluatedAt.Valid {
+		alert.LastEvaluatedAt = &lastEvaluatedAt.Time
+	}
+	if lastTriggeredAt.Valid {
+		alert.LastTriggeredAt = &lastTriggeredAt.Time
+	}
+	return alert, nil
+}
+
+func scanAlertHistory(scanner interface{ Scan(dest ...any) error }) (*models.AlertHistoryEntry, error) {
+	var (
+		id           int64
+		alertID      int64
+		status       string
+		triggeredAt  time.Time
+		resolvedAt   sql.NullTime
+		valueText    sql.NullString
+		channelsJSON sql.NullString
+		message      sql.NullString
+		createdAt    time.Time
+	)
+	if err := scanner.Scan(&id, &alertID, &status, &triggeredAt, &resolvedAt, &valueText, &channelsJSON, &message, &createdAt); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to scan alert history: %w", err)
+	}
+
+	var channels []models.AlertChannel
+	if channelsJSON.Valid && channelsJSON.String != "" {
+		if err := json.Unmarshal([]byte(channelsJSON.String), &channels); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal alert history channels: %w", err)
+		}
+	}
+
+	entry := &models.AlertHistoryEntry{
+		ID:          id,
+		AlertID:     models.AlertID(alertID),
+		Status:      models.AlertStatus(status),
+		TriggeredAt: triggeredAt,
+		ValueText:   valueText.String,
+		Channels:    channels,
+		Message:     message.String,
+		CreatedAt:   createdAt,
+	}
+	if resolvedAt.Valid {
+		entry.ResolvedAt = &resolvedAt.Time
+	}
+	return entry, nil
+}
+
+func nullableString(value string) interface{} {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/sqlite/migrations/000004_add_alerts.down.sql
+++ b/internal/sqlite/migrations/000004_add_alerts.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS alert_history;
+DROP TABLE IF EXISTS alerts;

--- a/internal/sqlite/migrations/000004_add_alerts.up.sql
+++ b/internal/sqlite/migrations/000004_add_alerts.up.sql
@@ -1,0 +1,43 @@
+-- Create alerts table for monitoring query thresholds
+CREATE TABLE IF NOT EXISTS alerts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    team_id INTEGER NOT NULL,
+    source_id INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT,
+    query_type TEXT NOT NULL CHECK (query_type IN ('sql', 'log_condition')),
+    query TEXT NOT NULL,
+    lookback_seconds INTEGER NOT NULL DEFAULT 300,
+    threshold_operator TEXT NOT NULL CHECK (threshold_operator IN ('gt', 'gte', 'lt', 'lte', 'eq', 'neq')),
+    threshold_value REAL NOT NULL,
+    frequency_seconds INTEGER NOT NULL DEFAULT 300,
+    severity TEXT NOT NULL CHECK (severity IN ('info', 'warning', 'critical')),
+    channels TEXT NOT NULL,
+    is_active INTEGER NOT NULL DEFAULT 1 CHECK (is_active IN (0, 1)),
+    last_evaluated_at DATETIME,
+    last_triggered_at DATETIME,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE CASCADE,
+    FOREIGN KEY (source_id) REFERENCES sources(id) ON DELETE CASCADE
+);
+
+-- Alert execution history for troubleshooting and resolution
+CREATE TABLE IF NOT EXISTS alert_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    alert_id INTEGER NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('triggered', 'resolved')),
+    triggered_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    resolved_at DATETIME,
+    value_text TEXT,
+    channels TEXT,
+    message TEXT,
+    created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (alert_id) REFERENCES alerts(id) ON DELETE CASCADE
+);
+
+-- Helpful indexes for common lookups
+CREATE INDEX IF NOT EXISTS idx_alerts_team_source ON alerts(team_id, source_id);
+CREATE INDEX IF NOT EXISTS idx_alerts_active ON alerts(is_active);
+CREATE INDEX IF NOT EXISTS idx_alerts_last_evaluated ON alerts(last_evaluated_at);
+CREATE INDEX IF NOT EXISTS idx_alert_history_alert_id ON alert_history(alert_id);

--- a/internal/sqlite/queries.sql
+++ b/internal/sqlite/queries.sql
@@ -317,3 +317,107 @@ DELETE FROM api_tokens WHERE id = ? AND user_id = ?;
 -- name: DeleteExpiredAPITokens :exec
 -- Delete all expired API tokens
 DELETE FROM api_tokens WHERE expires_at IS NOT NULL AND expires_at < datetime('now');
+
+-- Alerts
+
+-- name: CreateAlert :one
+INSERT INTO alerts (
+    team_id,
+    source_id,
+    name,
+    description,
+    query_type,
+    query,
+    lookback_seconds,
+    threshold_operator,
+    threshold_value,
+    frequency_seconds,
+    severity,
+    channels,
+    is_active
+)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id;
+
+-- name: GetAlert :one
+SELECT * FROM alerts WHERE id = ?;
+
+-- name: GetAlertForTeamSource :one
+SELECT * FROM alerts WHERE id = ? AND team_id = ? AND source_id = ?;
+
+-- name: ListAlertsByTeamAndSource :many
+SELECT * FROM alerts
+WHERE team_id = ? AND source_id = ?
+ORDER BY created_at DESC;
+
+-- name: UpdateAlert :exec
+UPDATE alerts
+SET name = ?,
+    description = ?,
+    query_type = ?,
+    query = ?,
+    lookback_seconds = ?,
+    threshold_operator = ?,
+    threshold_value = ?,
+    frequency_seconds = ?,
+    severity = ?,
+    channels = ?,
+    is_active = ?,
+    updated_at = datetime('now')
+WHERE id = ?;
+
+-- name: DeleteAlert :exec
+DELETE FROM alerts WHERE id = ?;
+
+-- name: MarkAlertEvaluated :exec
+UPDATE alerts
+SET last_evaluated_at = datetime('now'),
+    updated_at = datetime('now')
+WHERE id = ?;
+
+-- name: MarkAlertTriggered :exec
+UPDATE alerts
+SET last_triggered_at = datetime('now'),
+    last_evaluated_at = datetime('now'),
+    updated_at = datetime('now')
+WHERE id = ?;
+
+-- name: ListActiveAlertsDue :many
+SELECT * FROM alerts
+WHERE is_active = 1
+  AND (
+        last_evaluated_at IS NULL
+        OR last_evaluated_at <= datetime('now', '-' || frequency_seconds || ' seconds')
+      );
+
+-- Alert history queries
+
+-- name: InsertAlertHistory :one
+INSERT INTO alert_history (
+    alert_id,
+    status,
+    value_text,
+    channels,
+    message
+)
+VALUES (?, ?, ?, ?, ?)
+RETURNING id;
+
+-- name: ResolveAlertHistory :exec
+UPDATE alert_history
+SET status = 'resolved',
+    resolved_at = datetime('now'),
+    message = ?
+WHERE id = ?;
+
+-- name: GetLatestUnresolvedAlertHistory :one
+SELECT * FROM alert_history
+WHERE alert_id = ? AND status = 'triggered'
+ORDER BY triggered_at DESC
+LIMIT 1;
+
+-- name: ListAlertHistory :many
+SELECT * FROM alert_history
+WHERE alert_id = ?
+ORDER BY triggered_at DESC
+LIMIT ?;

--- a/pkg/models/alerts.go
+++ b/pkg/models/alerts.go
@@ -1,0 +1,132 @@
+package models
+
+import "time"
+
+// AlertQueryType represents the strategy used to evaluate an alert.
+type AlertQueryType string
+
+const (
+	// AlertQueryTypeSQL indicates a raw SQL query will be executed against ClickHouse.
+	AlertQueryTypeSQL AlertQueryType = "sql"
+	// AlertQueryTypeLogCondition indicates a filter-based condition evaluated over recent logs.
+	AlertQueryTypeLogCondition AlertQueryType = "log_condition"
+)
+
+// AlertThresholdOperator represents the comparison operator used when checking the evaluated value.
+type AlertThresholdOperator string
+
+const (
+	AlertThresholdGreaterThan        AlertThresholdOperator = "gt"
+	AlertThresholdGreaterThanOrEqual AlertThresholdOperator = "gte"
+	AlertThresholdLessThan           AlertThresholdOperator = "lt"
+	AlertThresholdLessThanOrEqual    AlertThresholdOperator = "lte"
+	AlertThresholdEqual              AlertThresholdOperator = "eq"
+	AlertThresholdNotEqual           AlertThresholdOperator = "neq"
+)
+
+// AlertSeverity is a lightweight severity indicator for routing and display.
+type AlertSeverity string
+
+const (
+	AlertSeverityInfo     AlertSeverity = "info"
+	AlertSeverityWarning  AlertSeverity = "warning"
+	AlertSeverityCritical AlertSeverity = "critical"
+)
+
+// AlertStatus captures the lifecycle state of an alert history entry.
+type AlertStatus string
+
+const (
+	AlertStatusTriggered AlertStatus = "triggered"
+	AlertStatusResolved  AlertStatus = "resolved"
+)
+
+// AlertChannelType enumerates supported outbound notification channels.
+type AlertChannelType string
+
+const (
+	AlertChannelEmail   AlertChannelType = "email"
+	AlertChannelSlack   AlertChannelType = "slack"
+	AlertChannelWebhook AlertChannelType = "webhook"
+)
+
+// AlertChannel represents a single notification target.
+type AlertChannel struct {
+	Type   AlertChannelType `json:"type"`
+	Target string           `json:"target"`
+	// Metadata allows the UI to store channel specific configuration.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// Alert encapsulates a rule that is continuously evaluated against log data.
+type Alert struct {
+	ID                AlertID                `json:"id"`
+	TeamID            TeamID                 `json:"team_id"`
+	SourceID          SourceID               `json:"source_id"`
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description,omitempty"`
+	QueryType         AlertQueryType         `json:"query_type"`
+	Query             string                 `json:"query"`
+	LookbackSeconds   int                    `json:"lookback_seconds"`
+	ThresholdOperator AlertThresholdOperator `json:"threshold_operator"`
+	ThresholdValue    float64                `json:"threshold_value"`
+	FrequencySeconds  int                    `json:"frequency_seconds"`
+	Severity          AlertSeverity          `json:"severity"`
+	Channels          []AlertChannel         `json:"channels"`
+	IsActive          bool                   `json:"is_active"`
+	LastEvaluatedAt   *time.Time             `json:"last_evaluated_at,omitempty"`
+	LastTriggeredAt   *time.Time             `json:"last_triggered_at,omitempty"`
+	CreatedAt         time.Time              `json:"created_at"`
+	UpdatedAt         time.Time              `json:"updated_at"`
+}
+
+// AlertHistoryEntry captures individual trigger or resolution events for an alert.
+type AlertHistoryEntry struct {
+	ID          int64          `json:"id"`
+	AlertID     AlertID        `json:"alert_id"`
+	Status      AlertStatus    `json:"status"`
+	TriggeredAt time.Time      `json:"triggered_at"`
+	ResolvedAt  *time.Time     `json:"resolved_at,omitempty"`
+	ValueText   string         `json:"value_text"`
+	Channels    []AlertChannel `json:"channels"`
+	Message     string         `json:"message,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+}
+
+// CreateAlertRequest defines the payload required to create a new alert rule.
+type CreateAlertRequest struct {
+	Name              string                 `json:"name"`
+	Description       string                 `json:"description"`
+	QueryType         AlertQueryType         `json:"query_type"`
+	Query             string                 `json:"query"`
+	LookbackSeconds   int                    `json:"lookback_seconds"`
+	ThresholdOperator AlertThresholdOperator `json:"threshold_operator"`
+	ThresholdValue    float64                `json:"threshold_value"`
+	FrequencySeconds  int                    `json:"frequency_seconds"`
+	Severity          AlertSeverity          `json:"severity"`
+	Channels          []AlertChannel         `json:"channels"`
+	IsActive          bool                   `json:"is_active"`
+}
+
+// UpdateAlertRequest defines updatable fields for an alert rule.
+type UpdateAlertRequest struct {
+	Name              *string                 `json:"name"`
+	Description       *string                 `json:"description"`
+	QueryType         *AlertQueryType         `json:"query_type"`
+	Query             *string                 `json:"query"`
+	LookbackSeconds   *int                    `json:"lookback_seconds"`
+	ThresholdOperator *AlertThresholdOperator `json:"threshold_operator"`
+	ThresholdValue    *float64                `json:"threshold_value"`
+	FrequencySeconds  *int                    `json:"frequency_seconds"`
+	Severity          *AlertSeverity          `json:"severity"`
+	Channels          *[]AlertChannel         `json:"channels"`
+	IsActive          *bool                   `json:"is_active"`
+}
+
+// ResolveAlertRequest allows callers to provide context when manually resolving an alert.
+type ResolveAlertRequest struct {
+	Message string `json:"message"`
+}
+
+// DefaultAlertHistoryLimit controls the number of history entries returned when unspecified.
+const DefaultAlertHistoryLimit = 50

--- a/pkg/models/common.go
+++ b/pkg/models/common.go
@@ -18,6 +18,9 @@ type (
 
 	// SessionID represents a unique session identifier
 	SessionID string
+
+	// AlertID represents a unique alert identifier
+	AlertID int64
 )
 
 // Timestamps provides common timestamp fields used across multiple models

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -6,6 +6,7 @@ sql:
       - "internal/sqlite/migrations/000001_init.up.sql"
       - "internal/sqlite/migrations/000002_add_editor_role.up.sql"
       - "internal/sqlite/migrations/000003_add_api_tokens.up.sql"
+      - "internal/sqlite/migrations/000004_add_alerts.up.sql"
     gen:
       go:
         package: "sqlc"


### PR DESCRIPTION
## Summary
- add SQLite pruning query to delete alert history rows past the configured retention limit
- trigger alert history pruning after inserting new trigger records
- cap alert history API responses using the configured history limit

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ee07fb04808320b7f7299bc23972d3