### PR TITLE
feat(collections): add bookmark and shareable URL support

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@types/echarts':
         specifier: ^5.0.0
         version: 5.0.0
+      '@types/lodash':
+        specifier: ^4.17.16
+        version: 4.17.21
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
@@ -65,6 +68,9 @@ importers:
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
@@ -1933,6 +1939,9 @@ packages:
 
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -4570,6 +4579,8 @@ snapshots:
   lines-and-columns@1.2.4: {}
 
   lodash-es@4.17.21: {}
+
+  lodash@4.17.21: {}
 
   loupe@3.2.1: {}
 

--- a/frontend/src/api/apiUtils.ts
+++ b/frontend/src/api/apiUtils.ts
@@ -5,7 +5,7 @@ import type { APIResponse } from "./types";
  * Generic API request function to reduce repetitive code
  */
 export async function apiRequest<T>(
-  method: "get" | "post" | "put" | "delete",
+  method: "get" | "post" | "put" | "patch" | "delete",
   url: string,
   data?: any,
   options?: { timeout?: number; signal?: AbortSignal }
@@ -19,6 +19,7 @@ export async function apiRequest<T>(
   if (method === "get" || method === "delete") {
     response = await api[method]<APIResponse<T>>(url, config);
   } else {
+    // post, put, patch all send data in body
     response = await api[method]<APIResponse<T>>(url, data, config);
   }
   return response.data;
@@ -31,5 +32,6 @@ export const apiClient = {
   get: <T>(url: string, options?: { timeout?: number; signal?: AbortSignal }) => apiRequest<T>("get", url, undefined, options),
   post: <T>(url: string, data?: any, options?: { timeout?: number; signal?: AbortSignal }) => apiRequest<T>("post", url, data, options),
   put: <T>(url: string, data?: any, options?: { timeout?: number; signal?: AbortSignal }) => apiRequest<T>("put", url, data, options),
+  patch: <T>(url: string, data?: any, options?: { timeout?: number; signal?: AbortSignal }) => apiRequest<T>("patch", url, data, options),
   delete: <T>(url: string, options?: { timeout?: number; signal?: AbortSignal }) => apiRequest<T>("delete", url, undefined, options)
 };

--- a/frontend/src/api/savedQueries.ts
+++ b/frontend/src/api/savedQueries.ts
@@ -27,8 +27,17 @@ export interface SavedTeamQuery {
   description: string;
   query_type: string;
   query_content: string; // JSON string of SavedQueryContent
+  is_bookmarked: boolean;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Toggle bookmark response
+ */
+export interface ToggleBookmarkResponse {
+  is_bookmarked: boolean;
+  message: string;
 }
 
 /**
@@ -76,6 +85,9 @@ export const savedQueriesApi = {
 
   deleteTeamSourceQuery: (teamId: number, sourceId: number, collectionId: string) =>
     apiClient.delete<{ success: boolean }>(`/teams/${teamId}/sources/${sourceId}/collections/${collectionId}`),
+
+  toggleBookmark: (teamId: number, sourceId: number, collectionId: number) =>
+    apiClient.patch<ToggleBookmarkResponse>(`/teams/${teamId}/sources/${sourceId}/collections/${collectionId}/bookmark`),
 
   // For retrieving user teams
   getUserTeams: () => apiClient.get<Team[]>("/me/teams")

--- a/frontend/src/composables/useSavedQueries.ts
+++ b/frontend/src/composables/useSavedQueries.ts
@@ -49,7 +49,7 @@ export function useSavedQueries(
   const isLoadingQueryDetails = ref(false)
   const searchQuery = ref('')
 
-  const isEditingExistingQuery = computed(() => !!route.query.collection_id);
+  const isEditingExistingQuery = computed(() => !!route.query.query_id);
 
   const canManageCollections = computed(() => {
     if (!authStore.isAuthenticated || !authStore.user) {
@@ -506,58 +506,10 @@ export function useSavedQueries(
     }
   }
 
-  // Generate URL for a saved query
+  // Generate shareable URL for a saved query
   function getQueryUrl(query: SavedTeamQuery): string {
-    try {
-      // Get query type from the saved query - ensure it's normalized
-      const queryType = query.query_type?.toLowerCase() === 'logchefql' ? 'logchefql' : 'sql'
-      console.log(`Building URL for query ${query.id} with type ${queryType}`)
-
-      // Parse the query content
-      const queryContent = JSON.parse(query.query_content)
-
-      // Build the URL with the appropriate parameters
-      let url = `/logs/explore?team=${query.team_id}`
-
-      // Add source ID if available
-      if (query.source_id) {
-        url += `&source=${query.source_id}`
-      }
-
-      // Add query ID for editing
-      url += `&query_id=${query.id}`
-
-      // Add limit if available
-      if (queryContent.limit) {
-        url += `&limit=${queryContent.limit}`
-      }
-
-      // Always add time range if available - this is crucial for query execution
-      if (queryContent.timeRange !== null &&
-          queryContent.timeRange?.absolute?.start &&
-          queryContent.timeRange?.absolute?.end) {
-        url += `&start=${queryContent.timeRange.absolute.start}`
-        url += `&end=${queryContent.timeRange.absolute.end}`
-      }
-
-      // Add mode parameter based on query type
-      url += `&mode=${queryType}`
-
-      // Add the query content (actual query text)
-      if (queryContent.content) {
-        if (queryType === 'logchefql') {
-          url += `&q=${encodeURIComponent(queryContent.content)}`
-        } else {
-          url += `&sql=${encodeURIComponent(queryContent.content)}`
-        }
-      }
-
-      return url
-    } catch (error) {
-      console.error('Error generating query URL:', error)
-      // Fallback URL with explicit mode parameter
-      return `/logs/explore?team=${query.team_id}&source=${query.source_id}&mode=${query.query_type?.toLowerCase() === 'logchefql' ? 'logchefql' : 'sql'}`
-    }
+    // Use the new shareable collection URL format
+    return `/logs/collection/${query.team_id}/${query.source_id}/${query.id}`
   }
 
   // Handle opening query in explorer

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -114,6 +114,15 @@ const routes: RouteRecordRaw[] = [
         }),
         meta: { title: "Alert Detail" },
       },
+      {
+        path: "collection/:teamId/:sourceId/:collectionId",
+        name: "CollectionRedirect",
+        component: () => import("@/views/collections/CollectionRedirect.vue").catch(err => {
+          error("Router", "Failed to load CollectionRedirect component", err);
+          return { default: ComponentLoadError };
+        }),
+        meta: { title: "Loading Collection..." },
+      },
     ],
   },
   // Management Section (Admin only)

--- a/frontend/src/views/collections/CollectionRedirect.vue
+++ b/frontend/src/views/collections/CollectionRedirect.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { Loader2, AlertCircle } from 'lucide-vue-next';
+import { Button } from '@/components/ui/button';
+
+const route = useRoute();
+const router = useRouter();
+
+const error = ref<string | null>(null);
+const isLoading = ref(true);
+
+onMounted(async () => {
+  const { teamId, sourceId, collectionId } = route.params;
+
+  // Validate params
+  if (!teamId || !sourceId || !collectionId) {
+    error.value = 'Invalid collection URL. Missing required parameters.';
+    isLoading.value = false;
+    return;
+  }
+
+  // Validate params are numeric
+  const teamIdNum = parseInt(teamId as string);
+  const sourceIdNum = parseInt(sourceId as string);
+  const collectionIdNum = parseInt(collectionId as string);
+
+  if (isNaN(teamIdNum) || isNaN(sourceIdNum) || isNaN(collectionIdNum)) {
+    error.value = 'Invalid collection URL. Parameters must be numeric.';
+    isLoading.value = false;
+    return;
+  }
+
+  // Redirect to explore with query params
+  try {
+    await router.replace({
+      path: '/logs/explore',
+      query: {
+        team: teamId as string,
+        source: sourceId as string,
+        query_id: collectionId as string,
+      },
+    });
+  } catch (err) {
+    console.error('Failed to redirect to collection:', err);
+    error.value = 'Failed to load collection. Please try again or check your permissions.';
+    isLoading.value = false;
+  }
+});
+
+function goToCollections() {
+  router.push('/logs/saved');
+}
+</script>
+
+<template>
+  <div class="flex flex-col items-center justify-center h-screen gap-4">
+    <!-- Loading state -->
+    <template v-if="isLoading && !error">
+      <Loader2 class="h-8 w-8 animate-spin text-primary" />
+      <p class="text-muted-foreground">Loading collection...</p>
+    </template>
+
+    <!-- Error state -->
+    <template v-if="error">
+      <div class="flex flex-col items-center gap-4 text-center">
+        <AlertCircle class="h-12 w-12 text-destructive" />
+        <h2 class="text-xl font-semibold">Unable to Load Collection</h2>
+        <p class="text-muted-foreground max-w-md">{{ error }}</p>
+        <Button @click="goToCollections">
+          Go to Collections
+        </Button>
+      </div>
+    </template>
+  </div>
+</template>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -244,6 +244,7 @@ func (s *Server) setupRoutes() {
 			collections.Post("/", s.requireCollectionManagement, s.handleCreateTeamSourceCollection)
 			collections.Put("/:collectionID", s.requireCollectionManagement, s.handleUpdateTeamSourceCollection)
 			collections.Delete("/:collectionID", s.requireCollectionManagement, s.handleDeleteTeamSourceCollection)
+			collections.Patch("/:collectionID/bookmark", s.requireCollectionManagement, s.handleToggleQueryBookmark)
 		}
 
 		alerts := teamSourceOps.Group("/alerts")

--- a/internal/sqlite/migrations/000006_add_bookmarks.down.sql
+++ b/internal/sqlite/migrations/000006_add_bookmarks.down.sql
@@ -1,0 +1,5 @@
+-- Remove bookmark index
+DROP INDEX IF EXISTS idx_team_queries_bookmarked;
+
+-- Remove is_bookmarked column from team_queries table
+ALTER TABLE team_queries DROP COLUMN is_bookmarked;

--- a/internal/sqlite/migrations/000006_add_bookmarks.up.sql
+++ b/internal/sqlite/migrations/000006_add_bookmarks.up.sql
@@ -1,0 +1,5 @@
+-- Add is_bookmarked column to team_queries table
+ALTER TABLE team_queries ADD COLUMN is_bookmarked BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Create index for efficient bookmark filtering and sorting
+CREATE INDEX IF NOT EXISTS idx_team_queries_bookmarked ON team_queries(team_id, source_id, is_bookmarked);

--- a/internal/sqlite/queries.sql
+++ b/internal/sqlite/queries.sql
@@ -236,8 +236,19 @@ DELETE FROM team_queries
 WHERE id = ? AND team_id = ? AND source_id = ?;
 
 -- name: ListQueriesByTeamAndSource :many
--- List all queries for a specific team and source
-SELECT * FROM team_queries WHERE team_id = ? AND source_id = ? ORDER BY created_at DESC;
+-- List all queries for a specific team and source (bookmarked first, then by updated_at)
+SELECT * FROM team_queries WHERE team_id = ? AND source_id = ? ORDER BY is_bookmarked DESC, updated_at DESC;
+
+-- name: ToggleQueryBookmark :exec
+-- Toggle the bookmark status of a query
+UPDATE team_queries
+SET is_bookmarked = NOT is_bookmarked,
+    updated_at = datetime('now')
+WHERE id = ? AND team_id = ? AND source_id = ?;
+
+-- name: GetQueryBookmarkStatus :one
+-- Get the current bookmark status of a query
+SELECT is_bookmarked FROM team_queries WHERE id = ? AND team_id = ? AND source_id = ?;
 
 -- Additional queries for user-source and team-source access
 

--- a/internal/sqlite/sqlc/db.go
+++ b/internal/sqlite/sqlc/db.go
@@ -102,6 +102,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getLatestUnresolvedAlertHistoryStmt, err = db.PrepareContext(ctx, getLatestUnresolvedAlertHistory); err != nil {
 		return nil, fmt.Errorf("error preparing query GetLatestUnresolvedAlertHistory: %w", err)
 	}
+	if q.getQueryBookmarkStatusStmt, err = db.PrepareContext(ctx, getQueryBookmarkStatus); err != nil {
+		return nil, fmt.Errorf("error preparing query GetQueryBookmarkStatus: %w", err)
+	}
 	if q.getSessionStmt, err = db.PrepareContext(ctx, getSession); err != nil {
 		return nil, fmt.Errorf("error preparing query GetSession: %w", err)
 	}
@@ -203,6 +206,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.teamHasSourceStmt, err = db.PrepareContext(ctx, teamHasSource); err != nil {
 		return nil, fmt.Errorf("error preparing query TeamHasSource: %w", err)
+	}
+	if q.toggleQueryBookmarkStmt, err = db.PrepareContext(ctx, toggleQueryBookmark); err != nil {
+		return nil, fmt.Errorf("error preparing query ToggleQueryBookmark: %w", err)
 	}
 	if q.updateAPITokenLastUsedStmt, err = db.PrepareContext(ctx, updateAPITokenLastUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAPITokenLastUsed: %w", err)
@@ -367,6 +373,11 @@ func (q *Queries) Close() error {
 	if q.getLatestUnresolvedAlertHistoryStmt != nil {
 		if cerr := q.getLatestUnresolvedAlertHistoryStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getLatestUnresolvedAlertHistoryStmt: %w", cerr)
+		}
+	}
+	if q.getQueryBookmarkStatusStmt != nil {
+		if cerr := q.getQueryBookmarkStatusStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getQueryBookmarkStatusStmt: %w", cerr)
 		}
 	}
 	if q.getSessionStmt != nil {
@@ -539,6 +550,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing teamHasSourceStmt: %w", cerr)
 		}
 	}
+	if q.toggleQueryBookmarkStmt != nil {
+		if cerr := q.toggleQueryBookmarkStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing toggleQueryBookmarkStmt: %w", cerr)
+		}
+	}
 	if q.updateAPITokenLastUsedStmt != nil {
 		if cerr := q.updateAPITokenLastUsedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateAPITokenLastUsedStmt: %w", cerr)
@@ -654,6 +670,7 @@ type Queries struct {
 	getAlertStmt                        *sql.Stmt
 	getAlertForTeamSourceStmt           *sql.Stmt
 	getLatestUnresolvedAlertHistoryStmt *sql.Stmt
+	getQueryBookmarkStatusStmt          *sql.Stmt
 	getSessionStmt                      *sql.Stmt
 	getSourceStmt                       *sql.Stmt
 	getSourceByNameStmt                 *sql.Stmt
@@ -688,6 +705,7 @@ type Queries struct {
 	removeTeamSourceStmt                *sql.Stmt
 	resolveAlertHistoryStmt             *sql.Stmt
 	teamHasSourceStmt                   *sql.Stmt
+	toggleQueryBookmarkStmt             *sql.Stmt
 	updateAPITokenLastUsedStmt          *sql.Stmt
 	updateAlertStmt                     *sql.Stmt
 	updateAlertHistoryPayloadStmt       *sql.Stmt
@@ -730,6 +748,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getAlertStmt:                        q.getAlertStmt,
 		getAlertForTeamSourceStmt:           q.getAlertForTeamSourceStmt,
 		getLatestUnresolvedAlertHistoryStmt: q.getLatestUnresolvedAlertHistoryStmt,
+		getQueryBookmarkStatusStmt:          q.getQueryBookmarkStatusStmt,
 		getSessionStmt:                      q.getSessionStmt,
 		getSourceStmt:                       q.getSourceStmt,
 		getSourceByNameStmt:                 q.getSourceByNameStmt,
@@ -764,6 +783,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		removeTeamSourceStmt:                q.removeTeamSourceStmt,
 		resolveAlertHistoryStmt:             q.resolveAlertHistoryStmt,
 		teamHasSourceStmt:                   q.teamHasSourceStmt,
+		toggleQueryBookmarkStmt:             q.toggleQueryBookmarkStmt,
 		updateAPITokenLastUsedStmt:          q.updateAPITokenLastUsedStmt,
 		updateAlertStmt:                     q.updateAlertStmt,
 		updateAlertHistoryPayloadStmt:       q.updateAlertHistoryPayloadStmt,

--- a/internal/sqlite/sqlc/models.go
+++ b/internal/sqlite/sqlc/models.go
@@ -118,6 +118,7 @@ type TeamQuery struct {
 	QueryContent string         `json:"query_content"`
 	CreatedAt    time.Time      `json:"created_at"`
 	UpdatedAt    time.Time      `json:"updated_at"`
+	IsBookmarked bool           `json:"is_bookmarked"`
 }
 
 type TeamSource struct {

--- a/internal/sqlite/sqlc/querier.go
+++ b/internal/sqlite/sqlc/querier.go
@@ -64,6 +64,8 @@ type Querier interface {
 	GetAlert(ctx context.Context, id int64) (Alert, error)
 	GetAlertForTeamSource(ctx context.Context, arg GetAlertForTeamSourceParams) (Alert, error)
 	GetLatestUnresolvedAlertHistory(ctx context.Context, alertID int64) (AlertHistory, error)
+	// Get the current bookmark status of a query
+	GetQueryBookmarkStatus(ctx context.Context, arg GetQueryBookmarkStatusParams) (bool, error)
 	// Get a session by ID
 	GetSession(ctx context.Context, id string) (Session, error)
 	// Get a single source by ID
@@ -91,7 +93,7 @@ type Querier interface {
 	ListActiveAlertsDue(ctx context.Context) ([]Alert, error)
 	ListAlertHistory(ctx context.Context, arg ListAlertHistoryParams) ([]AlertHistory, error)
 	ListAlertsByTeamAndSource(ctx context.Context, arg ListAlertsByTeamAndSourceParams) ([]Alert, error)
-	// List all queries for a specific team and source
+	// List all queries for a specific team and source (bookmarked first, then by updated_at)
 	ListQueriesByTeamAndSource(ctx context.Context, arg ListQueriesByTeamAndSourceParams) ([]TeamQuery, error)
 	// List all teams a data source is a member of
 	ListSourceTeams(ctx context.Context, sourceID int64) ([]Team, error)
@@ -125,6 +127,8 @@ type Querier interface {
 	// Additional queries for user-source and team-source access
 	// Check if a team has access to a source
 	TeamHasSource(ctx context.Context, arg TeamHasSourceParams) (int64, error)
+	// Toggle the bookmark status of a query
+	ToggleQueryBookmark(ctx context.Context, arg ToggleQueryBookmarkParams) error
 	// Update the last used timestamp for an API token
 	UpdateAPITokenLastUsed(ctx context.Context, id int64) error
 	UpdateAlert(ctx context.Context, arg UpdateAlertParams) error

--- a/pkg/models/query.go
+++ b/pkg/models/query.go
@@ -130,6 +130,7 @@ type SavedTeamQuery struct {
 	Description  string         `json:"description" db:"description"`
 	QueryType    SavedQueryType `json:"query_type" db:"query_type"`
 	QueryContent string         `json:"query_content" db:"query_content"` // JSON string of SavedQueryContent
+	IsBookmarked bool           `json:"is_bookmarked" db:"is_bookmarked"`
 	CreatedAt    time.Time      `json:"created_at" db:"created_at"`
 	UpdatedAt    time.Time      `json:"updated_at" db:"updated_at"`
 }

--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -8,6 +8,7 @@ sql:
       - "internal/sqlite/migrations/000003_add_api_tokens.up.sql"
       - "internal/sqlite/migrations/000004_add_alerts.up.sql"
       - "internal/sqlite/migrations/000005_add_system_settings.up.sql"
+      - "internal/sqlite/migrations/000006_add_bookmarks.up.sql"
     gen:
       go:
         package: "sqlc"


### PR DESCRIPTION
## Summary

Closes https://github.com/mr-karan/logchef/issues/5

This enables teams to share collection URLs and update the underlying queries in the future without resharing the URLs - the same link continues to work with updated content.

**Features added:**
- Bookmark toggle (`is_bookmarked` field) - bookmarked queries sort to top with visual star indicator
- Shareable URLs: `/logs/collection/{teamId}/{sourceId}/{collectionId}` for direct sharing
- CollectionRedirect component for URL handling with error states
- Star icon in dropdown and collections view (amber when bookmarked)
- Copy link functionality with toast notification
- "Update Current Query" in Explorer to save modified queries back to same collection
- Query name links now use shareable URL format
- Local re-sorting after bookmark toggle (bookmarked items move to top immediately)

**Backend changes:**
- Migration adding `is_bookmarked` column to `team_queries` table
- Toggle bookmark API endpoint (PATCH)
- Updated query ordering (bookmarked first, then by updated_at desc)

**Frontend changes:**
- Added `patch` method to apiClient
- Local re-sorting after bookmark toggle with updated_at sync
- Fixed `isEditingExistingQuery` detection (query_id param)
- Fixed SaveQueryModal to use content from initialData in edit mode
- Added @update handler in SavedQueriesView
- Navigation error handling in CollectionRedirect

## Test plan

- [x] Navigate to Collections view, verify star icons appear
- [x] Click star to bookmark - verify it fills amber and query moves to top
- [x] Click "Copy Link" in dropdown - verify toast and clipboard content
- [x] Open shareable URL `/logs/collection/1/1/1` - verify redirect to Explorer
- [x] Modify query in Explorer, click Collections > "Update Current Query"
- [x] Verify updated query is saved and shareable URL loads new content
- [x] Test invalid collection URLs show error state (403)
- [x] Test re-ordering: bookmark a query and verify it moves to top immediately