### PR TITLE
fix: respect SQL LIMIT clause in query execution

### DIFF
--- a/frontend/src/services/SqlManager.ts
+++ b/frontend/src/services/SqlManager.ts
@@ -161,6 +161,33 @@ LIMIT ${limit}`;
   }
 
   /**
+   * Extract the LIMIT value from a SQL query
+   * @param sql The SQL query to parse
+   * @returns The limit value if found, null otherwise
+   */
+  static extractLimitFromSql(sql: string): number | null {
+    if (!sql || !sql.trim()) {
+      return null;
+    }
+
+    try {
+      // Match LIMIT followed by a number, handling optional whitespace and semicolons
+      const limitRegex = /\bLIMIT\s+(\d+)\s*(?:;|\s|$)/i;
+      const match = sql.match(limitRegex);
+
+      if (match && match[1]) {
+        const limit = parseInt(match[1], 10);
+        return isNaN(limit) ? null : limit;
+      }
+
+      return null;
+    } catch (error) {
+      console.error("SqlManager: Error extracting limit from SQL:", error);
+      return null;
+    }
+  }
+
+  /**
    * Update SQL query with new limit
    * @param sql The SQL query to update
    * @param limit The new limit value

--- a/frontend/src/stores/explore.ts
+++ b/frontend/src/stores/explore.ts
@@ -743,9 +743,18 @@ export const useExploreStore = defineStore("explore", () => {
 
       let sql = sqlForExecution.value;
 
+      // Extract limit from SQL if present, otherwise use store's limit
+      const sqlLimit = SqlManager.extractLimitFromSql(sql || '');
+      const effectiveLimit = sqlLimit !== null ? sqlLimit : state.data.value.limit;
+
+      // Sync store's limit with SQL's limit for UI consistency
+      if (sqlLimit !== null && sqlLimit !== state.data.value.limit) {
+        state.data.value.limit = sqlLimit;
+      }
+
       const params: QueryParams = {
         raw_sql: '',
-        limit: state.data.value.limit,
+        limit: effectiveLimit,
         query_timeout: state.data.value.queryTimeout
       };
 


### PR DESCRIPTION
## Problem

The frontend ignores the `LIMIT` clause in user's SQL query and always sends the default limit (100) to the API. This causes users to get only 100 rows even when they write `LIMIT 1000` in their query.

**Before:** User writes `LIMIT 1000` in SQL → API receives `limit: 100` → Returns 100 rows

## Solution

- Add `extractLimitFromSql()` to `SqlManager` to parse LIMIT from SQL
- Use parsed limit in `executeQuery()` instead of store default  
- Sync UI dropdown with SQL's limit value for consistency

**After:** User writes `LIMIT 1000` in SQL → API receives `limit: 1000` → Returns 1000 rows

## Testing

1. Go to `/logs/explore`
2. Write a SQL query with `LIMIT 1000`
3. Click Run Query
4. Verify the network request payload shows `limit: 1000`
5. Verify you get up to 1000 results