### PR TITLE
Fix persistent y-scroll bar on main content area in explorer view

### DIFF
--- a/frontend/src/views/explore/LogExplorer.vue
+++ b/frontend/src/views/explore/LogExplorer.vue
@@ -1368,6 +1368,11 @@ onBeforeUnmount(() => {
   max-height: 100%;
 }
 
+/* Fix padding for main content area to eliminate y-scroll bar */
+.log-explorer-wrapper {
+  margin: -0.75rem;
+}
+
 /* Force the results section to expand fully */
 .flex-1.overflow-hidden.flex.flex-col.border-t {
   flex: 1 1 auto !important;


### PR DESCRIPTION
The explore view always has a y-scroll bar due to padding on the main content area making the `height:100vh` applied to the view always overflow by `1.5rem`. This fixes that.

## Before screenshot
<img width="1700" height="842" alt="before" src="https://github.com/user-attachments/assets/3230ad40-d981-4653-a37c-00d83b935bc0" />

## After screenshot
<img width="1702" height="844" alt="after" src="https://github.com/user-attachments/assets/3346c85b-d7a7-406b-a09a-e37a9720d7fd" />
