### PR TITLE
feat: add skip_email_verified_check config option #85

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -50,6 +50,10 @@ cli_client_id = "logchef-cli"
 redirect_url = "http://localhost:8125/api/v1/auth/callback"
 # OIDC scopes to request.
 scopes = ["openid", "email", "profile"]
+# Keep false unless your OIDC provider omits email_verified while verifying
+# email addresses by other means. Missing/null email_verified is allowed only
+# when this is true; explicit email_verified=false is always rejected.
+skip_email_verified_check = false
 
 # -----------------------------------------------------------------------------
 # Authentication (required)

--- a/docs/src/content/docs/getting-started/configuration.md
+++ b/docs/src/content/docs/getting-started/configuration.md
@@ -88,11 +88,19 @@ redirect_url = "http://localhost:8125/api/v1/auth/callback"
 
 # Required OIDC scopes
 scopes = ["openid", "email", "profile"]
+
+# Keep false unless your OIDC provider omits email_verified while verifying
+# email addresses by other means. Missing/null email_verified is allowed only
+# when this is true; explicit email_verified=false is always rejected.
+skip_email_verified_check = false
 ```
 
 If you plan to use the CLI, create a public OIDC client with loopback redirect URIs
 (`http://127.0.0.1:19876/callback` through `http://127.0.0.1:19878/callback`) and set
 `oidc.cli_client_id` to that client ID.
+
+`oidc.skip_email_verified_check` is useful for providers such as Cloudflare Access that do not emit
+the `email_verified` claim. It does not bypass an explicit `email_verified=false` response.
 
 ### Auth Settings
 

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -30,6 +30,41 @@ var (
 	ErrAdminNotFound             = errors.New("admin not found") // May not be needed if admin check moves to core
 )
 
+// OIDCClaims represents the claims extracted from an OIDC ID token.
+// EmailVerified is a *bool to distinguish between a missing/null claim
+// (nil) and an explicit false value. This matters for providers like
+// Cloudflare Access that omit the claim entirely.
+type OIDCClaims struct {
+	Email         string `json:"email"`
+	EmailVerified *bool  `json:"email_verified"`
+	Name          string `json:"name"`
+}
+
+// CheckEmailVerified validates the email_verified claim according to the
+// skip_email_verified_check configuration. The three cases are:
+//   - claim is true: always allowed.
+//   - claim is missing/null (nil): allowed only when skipCheck is true.
+//   - claim is explicitly false: always rejected, even when skipCheck is true.
+func CheckEmailVerified(claims OIDCClaims, skipCheck bool, log *slog.Logger, context string) error {
+	switch {
+	case claims.EmailVerified != nil && *claims.EmailVerified:
+		// Email is verified, nothing to do.
+		return nil
+	case claims.EmailVerified != nil && !*claims.EmailVerified:
+		// Provider explicitly says email is NOT verified — always reject.
+		log.Warn(context+": email_verified is explicitly false", "email", claims.Email)
+		return ErrOIDCEmailNotVerified
+	default:
+		// Claim is missing/null.
+		if skipCheck {
+			log.Warn(context+": email_verified claim is missing, proceeding anyway (skip_email_verified_check=true)", "email", claims.Email)
+			return nil
+		}
+		log.Warn(context+": email_verified claim is missing", "email", claims.Email)
+		return ErrOIDCEmailNotVerified
+	}
+}
+
 // OIDCProvider handles OIDC authentication interactions.
 type OIDCProvider struct {
 	provider  *oidc.Provider
@@ -133,20 +168,15 @@ func (p *OIDCProvider) HandleCallback(ctx context.Context, db *sqlite.DB, log *s
 	}
 
 	// Extract required claims.
-	var claims struct {
-		Email         string `json:"email"`
-		EmailVerified bool   `json:"email_verified"`
-		Name          string `json:"name"`
-	}
+	var claims OIDCClaims
 	if err := idToken.Claims(&claims); err != nil {
 		p.log.Error("failed to parse ID token claims", "error", err)
 		return nil, nil, fmt.Errorf("%w: failed to parse ID token claims: %v", ErrOIDCInvalidToken, err)
 	}
 
-	// Ensure email is verified by the OIDC provider.
-	if !claims.EmailVerified {
-		p.log.Warn("OIDC login attempt with unverified email", "email", claims.Email)
-		return nil, nil, ErrOIDCEmailNotVerified
+	// Verify email_verified claim.
+	if err := CheckEmailVerified(claims, p.oidcCfg.SkipEmailVerifiedCheck, p.log, "OIDC callback"); err != nil {
+		return nil, nil, err
 	}
 
 	// Look up user in the local database.

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestCheckEmailVerified(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	tests := []struct {
+		name      string
+		claims    OIDCClaims
+		skipCheck bool
+		wantErr   bool
+	}{
+		// Default behavior (skipCheck = false)
+		{
+			name:      "default: email_verified true allows login",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: boolPtr(true)},
+			skipCheck: false,
+			wantErr:   false,
+		},
+		{
+			name:      "default: email_verified explicitly false rejects",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: boolPtr(false)},
+			skipCheck: false,
+			wantErr:   true,
+		},
+		{
+			name:      "default: email_verified missing rejects",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: nil},
+			skipCheck: false,
+			wantErr:   true,
+		},
+
+		// skip_email_verified_check = true
+		{
+			name:      "skip: email_verified true allows login",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: boolPtr(true)},
+			skipCheck: true,
+			wantErr:   false,
+		},
+		{
+			name:      "skip: email_verified explicitly false still rejects",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: boolPtr(false)},
+			skipCheck: true,
+			wantErr:   true,
+		},
+		{
+			name:      "skip: email_verified missing allows login",
+			claims:    OIDCClaims{Email: "a@b.com", EmailVerified: nil},
+			skipCheck: true,
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CheckEmailVerified(tt.claims, tt.skipCheck, log, "test")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CheckEmailVerified() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && !errors.Is(err, ErrOIDCEmailNotVerified) {
+				t.Errorf("CheckEmailVerified() expected ErrOIDCEmailNotVerified, got %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,13 @@ type OIDCConfig struct {
 	Scopes       []string `koanf:"scopes"`
 
 	CLIClientID string `koanf:"cli_client_id"`
+
+	// SkipEmailVerifiedCheck disables the email_verified claim check during
+	// OIDC authentication. Set to true only if your OIDC provider does not
+	// include the email_verified claim but the email address is verified by
+	// other means (e.g. Cloudflare Access, corporate SSO).
+	// Default: false
+	SkipEmailVerifiedCheck bool `koanf:"skip_email_verified_check"`
 }
 
 // AuthConfig contains authentication settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -80,6 +80,13 @@ type OIDCConfig struct {
 	Scopes       []string `koanf:"scopes"`
 
 	CLIClientID string `koanf:"cli_client_id"`
+
+	// SkipEmailVerifiedCheck disables the email_verified claim check during
+	// OIDC authentication. Set to true only if your OIDC provider does not
+	// include the email_verified claim but the email address is verified by
+	// other means (e.g. Cloudflare Access, corporate SSO).
+	// Default: false
+	SkipEmailVerifiedCheck bool `koanf:"skip_email_verified_check"`
 }
 
 // AuthConfig contains authentication settings

--- a/internal/server/auth_handlers.go
+++ b/internal/server/auth_handlers.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mr-karan/logchef/internal/auth"
 	"github.com/mr-karan/logchef/internal/core"
 	"github.com/mr-karan/logchef/pkg/models"
 
@@ -314,19 +315,14 @@ func (s *Server) handleCLITokenExchange(c *fiber.Ctx) error {
 	}
 
 	// Extract claims from the ID token
-	var claims struct {
-		Email         string `json:"email"`
-		EmailVerified bool   `json:"email_verified"`
-		Name          string `json:"name"`
-	}
+	var claims auth.OIDCClaims
 	if err := idToken.Claims(&claims); err != nil {
 		s.log.Error("CLI token exchange: failed to parse ID token claims", "error", err)
 		return SendErrorWithType(c, fiber.StatusUnauthorized, "Failed to parse token claims", models.AuthenticationErrorType)
 	}
 
-	// Ensure email is verified
-	if !claims.EmailVerified {
-		s.log.Warn("CLI token exchange: unverified email", "email", claims.Email)
+	// Verify email_verified claim.
+	if err := auth.CheckEmailVerified(claims, s.config.OIDC.SkipEmailVerifiedCheck, s.log, "CLI token exchange"); err != nil {
 		return SendErrorWithType(c, fiber.StatusUnauthorized, "Email not verified", models.AuthenticationErrorType)
 	}
 


### PR DESCRIPTION
Some OIDC providers do not include email_verified: true in their ID tokens even when the email address is definitively verified. One of the common case is Cloudflare Access acting as an OIDC SaaS provider as it authenticates users via an upstream corporate IdP (SAML/Okta) but does not propagate the email_verified claim into the tokens it issues downstream.

The check is currently unconditional in two places:

internal/auth/oidc.go — browser OIDC callback flow internal/server/auth_handlers.go — CLI token exchange flow This causes every login attempt to fail with ErrOIDCEmailNotVerified when using such providers, even though the email is known-good via corporate SSO.

Add skip_email_verified_check to OIDCConfig. Default is false, so existing behavior is unchanged for all current users.