### PR TITLE
fix: switch to SQL mode when inserting AI-generated query into editor

### DIFF
--- a/frontend/src/components/query-editor/QueryEditor.vue
+++ b/frontend/src/components/query-editor/QueryEditor.vue
@@ -13,7 +13,7 @@
 
         <!-- Tabs for Mode Switching -->
         <Tabs :model-value="props.activeMode"
-          @update:model-value="(value: string | number) => $emit('update:activeMode', asEditorMode(value), true)"
+          @update:model-value="(value: string | number) => $emit('update:activeMode', asEditorMode(value), false)"
           class="w-auto">
           <TabsList class="grid grid-cols-2 w-fit">
             <TabsTrigger value="logchefql">
@@ -795,8 +795,24 @@ const handleAiDialogSubmit = (payload: { naturalLanguageQuery: string; currentQu
 };
 
 const handleAiInsert = (sql: string) => {
+  // AI always generates raw SQL — write it directly to the SQL store
+  // before triggering mode switch so translation cannot overwrite it.
+  exploreStore.setRawSql(sql);
   editorContent.value = sql;
-  handleEditorChange(sql);
+
+  emit('change', {
+    query: sql,
+    mode: 'clickhouse-sql',
+    isUserInput: false,
+  });
+
+  // Switch to SQL tab if not already there (mirrors handleLoadQueryFromHistory)
+  if (props.activeMode !== 'clickhouse-sql') {
+    nextTick(() => {
+      emit('update:activeMode', 'clickhouse-sql' as EditorMode, true);
+    });
+  }
+
   showAiDialog.value = false;
   exploreStore.clearAiSqlState();
   nextTick(() => {

--- a/frontend/src/composables/useQuery.ts
+++ b/frontend/src/composables/useQuery.ts
@@ -126,12 +126,14 @@ export function useQuery() {
   };
 
   // Change query mode - uses backend as single source of truth for SQL generation
-  const changeMode = async (newMode: EditorMode, _isModeSwitchOnly: boolean = false) => {
+  // When isModeSwitchOnly is true, skip LogchefQL→SQL translation (e.g. AI insert,
+  // loading a saved SQL query) so existing rawSql content is preserved.
+  const changeMode = async (newMode: EditorMode, isModeSwitchOnly: boolean = false) => {
     // Clear any validation errors when changing modes
     queryError.value = '';
 
-    // If switching to SQL mode
-    if (newMode === 'sql' && activeMode.value === 'logchefql') {
+    // If switching to SQL mode and caller hasn't already set rawSql
+    if (newMode === 'sql' && activeMode.value === 'logchefql' && !isModeSwitchOnly) {
       // First, check if we have the actual generated SQL from a previous execution
       if (exploreStore.generatedDisplaySql) {
         exploreStore.setRawSql(exploreStore.generatedDisplaySql);


### PR DESCRIPTION
When the AI Assistant generates SQL and the user clicks "Insert into Editor", the query is inserted into whichever mode is currently active. If the editor is in Search (LogchefQL) mode, the generated SQL is written into the search bar and after executing produces: `Query Error: 1:8: lexer: invalid input text

Fix by switching the editor to SQL mode before inserting. The store is updated first (setRawSql + setActiveMode) to prevent the async LogchefQL-to-SQL translation in changeMode() from overwriting the generated query. A change event with explicit mode:'clickhouse-sql' and an update:activeMode emit ensure both the parent component and the tab UI reflect the switch.

Follows the same pattern used by handleLoadQueryFromHistory() for cross-mode programmatic updates.