### PR TITLE
fix(roles): editor permissions across stack + restore team admin /admin/teams access

### DIFF
--- a/frontend/src/components/collections/AddToCollectionDrawer.vue
+++ b/frontend/src/components/collections/AddToCollectionDrawer.vue
@@ -14,6 +14,7 @@ import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { useCollectionsStore } from "@/stores/collections";
 import { collectionsApi, type CollectionItem } from "@/api/collections";
+import { useTeamPermissions } from "@/composables/useTeamPermissions";
 import { useRouter } from "vue-router";
 
 const props = defineProps<{
@@ -28,6 +29,7 @@ const emit = defineEmits<{
 
 const router = useRouter();
 const store = useCollectionsStore();
+const { canManageCollection, isAnyTeamCollectionMutator } = useTeamPermissions();
 
 const isLoadingIndex = ref(false);
 const isMutating = ref<number | null>(null);
@@ -38,7 +40,9 @@ const isCreating = ref(false);
 // Map<collectionId, Set<queryId>> — built on open
 const itemIndex = ref<Map<number, Set<number>>>(new Map());
 
-const collections = computed(() => store.collections);
+// Only show collections the caller can mutate. Members see their personal
+// collection (auto-owner) but not shared collections they can't pin to.
+const collections = computed(() => store.collections.filter((c) => canManageCollection(c)));
 const isQueryInCollection = (collectionId: number) =>
   itemIndex.value.get(collectionId)?.has(props.queryId) ?? false;
 
@@ -177,7 +181,7 @@ function navigateToCollection(collectionId: number) {
 
           <Separator />
 
-          <div v-if="!showInlineCreate">
+          <div v-if="!showInlineCreate && isAnyTeamCollectionMutator">
             <Button variant="ghost" size="sm" class="w-full justify-start" @click="showInlineCreate = true">
               <Plus class="mr-2 h-4 w-4" />
               New Collection

--- a/frontend/src/components/collections/SavedQueriesDropdown.vue
+++ b/frontend/src/components/collections/SavedQueriesDropdown.vue
@@ -42,7 +42,7 @@ const authStore = useAuthStore();
 
 const {
   isEditingExistingQuery,
-  canManageCollections,
+  canSaveQuery,
 } = useSavedQueries();
 
 // Local state
@@ -185,16 +185,16 @@ async function copyCollectionUrl(event: Event, query: SavedQuery) {
       </Button>
     </DropdownMenuTrigger>
     <DropdownMenuContent class="w-64" align="end">
-      <DropdownMenuItem v-if="canManageCollections" @click="handleSave">
+      <DropdownMenuItem v-if="canSaveQuery" @click="handleSave">
         <Save class="w-4 h-4 mr-2" />
         <span>{{ isEditingExistingQuery ? 'Update Current Query' : 'Save Current Query to Collection...' }}</span>
       </DropdownMenuItem>
-      <DropdownMenuItem v-if="canManageCollections && isEditingExistingQuery" @click="handleRequestSaveAsNew">
+      <DropdownMenuItem v-if="canSaveQuery && isEditingExistingQuery" @click="handleRequestSaveAsNew">
         <PlusCircle class="w-4 h-4 mr-2" />
         <span>Save as New Query...</span>
       </DropdownMenuItem>
 
-      <DropdownMenuSeparator v-if="canManageCollections" />
+      <DropdownMenuSeparator v-if="canSaveQuery" />
 
       <DropdownMenuLabel v-if="hasQueries">Load from Collection</DropdownMenuLabel>
       <DropdownMenuSub v-if="hasQueries">

--- a/frontend/src/composables/__tests__/useTeamPermissions.test.ts
+++ b/frontend/src/composables/__tests__/useTeamPermissions.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { ref } from "vue";
+import type { User } from "@/types";
+import type { UserTeamMembership } from "@/api/teams";
+import type { SavedQuery } from "@/api/savedQueries";
+import type { Collection } from "@/api/collections";
+
+// Mock auth and teams stores. Real Pinia setup stores auto-unwrap refs at
+// the property access boundary, so the mocks expose getters that return the
+// unwrapped value. The composable reads `user.role` and `userTeams[]` — only
+// those two surfaces need mocking.
+const mockUser = ref<User | null>(null);
+const mockUserTeams = ref<UserTeamMembership[]>([]);
+
+vi.mock("@/stores/auth", () => ({
+  useAuthStore: () => ({
+    get user() {
+      return mockUser.value;
+    },
+    get isAuthenticated() {
+      return mockUser.value !== null;
+    },
+  }),
+}));
+
+vi.mock("@/stores/teams", () => ({
+  useTeamsStore: () => ({
+    get userTeams() {
+      return mockUserTeams.value;
+    },
+  }),
+}));
+
+// Import the composable AFTER the mocks are declared.
+const { useTeamPermissions } = await import("../useTeamPermissions");
+
+const baseUser = (overrides: Partial<User> = {}): User => ({
+  id: "10",
+  email: "user@example.com",
+  full_name: "User",
+  role: "member",
+  status: "active",
+  created_at: "",
+  updated_at: "",
+  ...overrides,
+});
+
+const baseTeam = (overrides: Partial<UserTeamMembership> = {}): UserTeamMembership => ({
+  id: 1,
+  name: "Team",
+  description: "",
+  created_at: "",
+  updated_at: "",
+  member_count: 1,
+  role: "member",
+  ...overrides,
+});
+
+function login(user: User | null, teams: UserTeamMembership[] = []) {
+  mockUser.value = user;
+  mockUserTeams.value = teams;
+}
+
+describe("useTeamPermissions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockUser.value = null;
+    mockUserTeams.value = [];
+  });
+
+  describe("isGlobalAdmin", () => {
+    it("true when global admin", () => {
+      login(baseUser({ role: "admin" }));
+      expect(useTeamPermissions().isGlobalAdmin.value).toBe(true);
+    });
+    it("false when global member", () => {
+      login(baseUser({ role: "member" }));
+      expect(useTeamPermissions().isGlobalAdmin.value).toBe(false);
+    });
+  });
+
+  describe("isAnyTeamAdmin", () => {
+    it("true when user is admin in any team", () => {
+      login(baseUser(), [baseTeam({ id: 1, role: "member" }), baseTeam({ id: 2, role: "admin" })]);
+      expect(useTeamPermissions().isAnyTeamAdmin.value).toBe(true);
+    });
+    it("false when user is only editor (does not count)", () => {
+      login(baseUser(), [baseTeam({ id: 1, role: "editor" })]);
+      expect(useTeamPermissions().isAnyTeamAdmin.value).toBe(false);
+    });
+    it("false when user has no teams", () => {
+      login(baseUser(), []);
+      expect(useTeamPermissions().isAnyTeamAdmin.value).toBe(false);
+    });
+    it("true for global admin even without team membership", () => {
+      login(baseUser({ role: "admin" }), []);
+      expect(useTeamPermissions().isAnyTeamAdmin.value).toBe(true);
+    });
+  });
+
+  describe("isAnyTeamCollectionMutator", () => {
+    it.each([
+      ["admin", true],
+      ["editor", true],
+      ["member", false],
+    ] as const)("role=%s → %s", (role, want) => {
+      login(baseUser(), [baseTeam({ id: 1, role })]);
+      expect(useTeamPermissions().isAnyTeamCollectionMutator.value).toBe(want);
+    });
+    it("true for global admin without team membership", () => {
+      login(baseUser({ role: "admin" }), []);
+      expect(useTeamPermissions().isAnyTeamCollectionMutator.value).toBe(true);
+    });
+  });
+
+  describe("isTeamCollectionMutator(teamId)", () => {
+    it("admin in team A is mutator in A, not in B", () => {
+      login(baseUser(), [
+        baseTeam({ id: 1, role: "admin" }),
+        baseTeam({ id: 2, role: "member" }),
+      ]);
+      const p = useTeamPermissions();
+      expect(p.isTeamCollectionMutator(1)).toBe(true);
+      expect(p.isTeamCollectionMutator(2)).toBe(false);
+    });
+    it("editor in team A is mutator in A, not in B", () => {
+      login(baseUser(), [
+        baseTeam({ id: 1, role: "editor" }),
+        baseTeam({ id: 2, role: "member" }),
+      ]);
+      const p = useTeamPermissions();
+      expect(p.isTeamCollectionMutator(1)).toBe(true);
+      expect(p.isTeamCollectionMutator(2)).toBe(false);
+    });
+    it("global admin is mutator in any team they aren't a member of", () => {
+      login(baseUser({ role: "admin" }), []);
+      expect(useTeamPermissions().isTeamCollectionMutator(99)).toBe(true);
+    });
+    it("null teamId returns false (unless global admin)", () => {
+      login(baseUser(), [baseTeam({ id: 1, role: "admin" })]);
+      expect(useTeamPermissions().isTeamCollectionMutator(null)).toBe(false);
+    });
+  });
+
+  describe("canSaveQuery", () => {
+    it("true when user has at least one team", () => {
+      login(baseUser(), [baseTeam({ id: 1, role: "member" })]);
+      expect(useTeamPermissions().canSaveQuery.value).toBe(true);
+    });
+    it("false when user has no teams (no source access possible)", () => {
+      login(baseUser(), []);
+      expect(useTeamPermissions().canSaveQuery.value).toBe(false);
+    });
+    it("true for global admin even without team membership", () => {
+      login(baseUser({ role: "admin" }), []);
+      expect(useTeamPermissions().canSaveQuery.value).toBe(true);
+    });
+    it("false when not authenticated", () => {
+      login(null);
+      expect(useTeamPermissions().canSaveQuery.value).toBe(false);
+    });
+  });
+
+  describe("canEditSavedQuery(query)", () => {
+    const creator = baseUser({ id: "10" });
+    const other = baseUser({ id: "20" });
+    const admin = baseUser({ id: "30", role: "admin" });
+    const query: SavedQuery = {
+      id: 1,
+      source_id: 1,
+      name: "q",
+      description: "",
+      query_type: "logchefql",
+      query_content: "",
+      created_by: 10,
+      created_at: "",
+      updated_at: "",
+    };
+
+    it("creator can edit", () => {
+      login(creator);
+      expect(useTeamPermissions().canEditSavedQuery(query)).toBe(true);
+    });
+    it("non-creator member cannot edit", () => {
+      login(other);
+      expect(useTeamPermissions().canEditSavedQuery(query)).toBe(false);
+    });
+    it("global admin can edit", () => {
+      login(admin);
+      expect(useTeamPermissions().canEditSavedQuery(query)).toBe(true);
+    });
+    it("null query is not editable", () => {
+      login(creator);
+      expect(useTeamPermissions().canEditSavedQuery(null)).toBe(false);
+    });
+    it("legacy NULL-creator query: non-admin cannot edit, global admin can", () => {
+      const legacy: SavedQuery = { ...query, created_by: undefined };
+      login(creator);
+      expect(useTeamPermissions().canEditSavedQuery(legacy)).toBe(false);
+      login(admin);
+      expect(useTeamPermissions().canEditSavedQuery(legacy)).toBe(true);
+    });
+  });
+
+  describe("canManageCollection(collection)", () => {
+    const owned: Collection = {
+      id: 1,
+      name: "owned",
+      is_personal: false,
+      created_by: 10,
+      caller_role: "owner",
+      member_count: 1,
+      item_count: 0,
+      created_at: "",
+      updated_at: "",
+    };
+    const memberRole: Collection = { ...owned, id: 2, caller_role: "member" };
+    const personal: Collection = { ...owned, id: 3, is_personal: true };
+
+    it("owner can manage", () => {
+      login(baseUser());
+      expect(useTeamPermissions().canManageCollection(owned)).toBe(true);
+    });
+    it("member role cannot manage", () => {
+      login(baseUser());
+      expect(useTeamPermissions().canManageCollection(memberRole)).toBe(false);
+    });
+    it("personal collection is manageable by its user (owner role)", () => {
+      login(baseUser());
+      expect(useTeamPermissions().canManageCollection(personal)).toBe(true);
+    });
+    it("global admin can manage any collection", () => {
+      login(baseUser({ role: "admin" }));
+      expect(useTeamPermissions().canManageCollection(memberRole)).toBe(true);
+    });
+    it("null collection is not manageable", () => {
+      login(baseUser());
+      expect(useTeamPermissions().canManageCollection(null)).toBe(false);
+    });
+  });
+});

--- a/frontend/src/composables/useSavedQueries.ts
+++ b/frontend/src/composables/useSavedQueries.ts
@@ -3,10 +3,9 @@ import { useRouter, useRoute } from 'vue-router'
 import { useExploreStore } from '@/stores/explore'
 import { useSavedQueriesStore } from '@/stores/savedQueries'
 import { useContextStore } from '@/stores/context'
-import { useAuthStore } from '@/stores/auth';
-import { useTeamsStore } from '@/stores/teams';
 import { useVariableStore } from '@/stores/variables'
 import type { VariableState } from '@/stores/variables'
+import { useTeamPermissions } from '@/composables/useTeamPermissions'
 import { useToast } from '@/composables/useToast'
 import { TOAST_DURATION } from '@/lib/constants'
 import { getErrorMessage } from '@/api/types'
@@ -37,7 +36,6 @@ export function useSavedQueries(
   const exploreStore = useExploreStore()
   const savedQueriesStore = useSavedQueriesStore()
   const contextStore = useContextStore()
-  const authStore = useAuthStore();
   const variableStore = useVariableStore();
   const { toast } = useToast()
 
@@ -50,20 +48,10 @@ export function useSavedQueries(
 
   const isEditingExistingQuery = computed(() => !!route.query.id);
 
-  // Collection mutations (create, invite, add items) require team admin/editor
-  // or global admin. Regular members can only view.
-  const teamsStore = useTeamsStore();
-  const canManageCollections = computed(() => {
-    if (!authStore.isAuthenticated || !authStore.user) return false;
-    if (authStore.user.role === 'admin') return true;
-    return teamsStore.isAnyTeamAdmin;
-  });
-
-  function canEditQuery(query: SavedQuery | null | undefined): boolean {
-    if (!query || !authStore.user) return false;
-    if (authStore.user.role === 'admin') return true;
-    return query.created_by != null && String(query.created_by) === String(authStore.user.id);
-  }
+  // Role gates delegate to useTeamPermissions so the matrix stays
+  // consistent with the backend role contract.
+  const { canSaveQuery, canEditSavedQuery, isAnyTeamCollectionMutator } = useTeamPermissions();
+  const canEditQuery = canEditSavedQuery;
 
   const filteredQueries = computed(() => {
     if (!searchQuery.value.trim()) {
@@ -562,8 +550,9 @@ export function useSavedQueries(
     totalQueryCount,
     searchQuery,
     isEditingExistingQuery,
-    canManageCollections,
+    canSaveQuery,
     canEditQuery,
+    isAnyTeamCollectionMutator,
 
     handleSaveQueryClick,
     handleSaveQuery,

--- a/frontend/src/composables/useTeamPermissions.ts
+++ b/frontend/src/composables/useTeamPermissions.ts
@@ -1,0 +1,88 @@
+/**
+ * Centralized role-check API for the UI. All gates that key on
+ * global / team / collection role should go through this composable so
+ * the mapping stays consistent with the backend. See
+ * `.plans/spec_roles_consistency.md` for the authoritative role matrix.
+ */
+import { computed } from "vue";
+import { useAuthStore } from "@/stores/auth";
+import { useTeamsStore } from "@/stores/teams";
+import type { SavedQuery } from "@/api/savedQueries";
+import type { Collection } from "@/api/collections";
+
+type TeamRole = "admin" | "editor" | "member";
+
+const TEAM_COLLECTION_MUTATOR_ROLES: ReadonlySet<TeamRole> = new Set(["admin", "editor"] as const);
+
+export function useTeamPermissions() {
+  const authStore = useAuthStore();
+  const teamsStore = useTeamsStore();
+
+  const isAuthenticated = computed(() => authStore.isAuthenticated);
+  const isGlobalAdmin = computed(() => authStore.user?.role === "admin");
+
+  function roleInTeam(teamId: number | null | undefined): TeamRole | null {
+    if (teamId == null) return null;
+    const team = teamsStore.userTeams.find((t) => t.id === teamId);
+    return (team?.role as TeamRole | undefined) ?? null;
+  }
+
+  function isTeamAdmin(teamId: number | null | undefined): boolean {
+    if (isGlobalAdmin.value) return true;
+    return roleInTeam(teamId) === "admin";
+  }
+
+  function isTeamCollectionMutator(teamId: number | null | undefined): boolean {
+    if (isGlobalAdmin.value) return true;
+    const role = roleInTeam(teamId);
+    return role != null && TEAM_COLLECTION_MUTATOR_ROLES.has(role);
+  }
+
+  const isAnyTeamAdmin = computed(() => {
+    if (isGlobalAdmin.value) return true;
+    return teamsStore.userTeams.some((t) => t.role === "admin");
+  });
+
+  const isAnyTeamCollectionMutator = computed(() => {
+    if (isGlobalAdmin.value) return true;
+    return teamsStore.userTeams.some((t) => TEAM_COLLECTION_MUTATOR_ROLES.has(t.role as TeamRole));
+  });
+
+  // Saved queries: anyone with source access (via any team) can save. Backend
+  // enforces source access; the UI only gates on "is the user a team member
+  // anywhere" because that's a precondition for having source access.
+  const canSaveQuery = computed(() => {
+    if (!isAuthenticated.value || !authStore.user) return false;
+    if (isGlobalAdmin.value) return true;
+    return teamsStore.userTeams.length > 0;
+  });
+
+  // Saved-query edit/delete is creator-owned (or global admin).
+  function canEditSavedQuery(query: SavedQuery | null | undefined): boolean {
+    if (!query || !authStore.user) return false;
+    if (isGlobalAdmin.value) return true;
+    return query.created_by != null && String(query.created_by) === String(authStore.user.id);
+  }
+
+  // Collection mutations require collection ownership at the per-resource
+  // level. The cross-team mutator gate is enforced by middleware on the
+  // backend, but the UI doesn't need that here — a non-owner viewing a
+  // collection just shouldn't see mutation affordances.
+  function canManageCollection(collection: Collection | null | undefined): boolean {
+    if (!collection) return false;
+    if (isGlobalAdmin.value) return true;
+    return collection.caller_role === "owner";
+  }
+
+  return {
+    isAuthenticated,
+    isGlobalAdmin,
+    isAnyTeamAdmin,
+    isAnyTeamCollectionMutator,
+    isTeamAdmin,
+    isTeamCollectionMutator,
+    canSaveQuery,
+    canEditSavedQuery,
+    canManageCollection,
+  };
+}

--- a/frontend/src/layouts/InnerApp.vue
+++ b/frontend/src/layouts/InnerApp.vue
@@ -55,6 +55,7 @@ import {
 } from "lucide-vue-next";
 
 import { useAuthStore } from "@/stores/auth";
+import { useTeamPermissions } from "@/composables/useTeamPermissions";
 import { useThemeStore, type ThemeMode } from "@/stores/theme";
 import { usePreferencesStore } from "@/stores/preferences";
 import { useMetaStore } from "@/stores/meta";
@@ -68,6 +69,7 @@ const preferencesStore = usePreferencesStore();
 const metaStore = useMetaStore();
 const teamsStore = useTeamsStore();
 const exploreStore = useExploreStore();
+const { isGlobalAdmin, isAnyTeamAdmin } = useTeamPermissions();
 
 const setThemePreference = (mode: ThemeMode) => {
   themeStore.setTheme(mode);
@@ -249,15 +251,14 @@ const navItems = [
             </SidebarGroupContent>
           </SidebarGroup>
 
-          <!-- Admin Navigation -->
-          <!-- Show for global admins OR team admins -->
-          <SidebarGroup v-if="authStore.user?.role === 'admin' || teamsStore.isAnyTeamAdmin" class="mt-4">
+          <!-- Administration section: visible to global admins and any-team admins.
+               Global admins see every item; team admins see only Teams. -->
+          <SidebarGroup v-if="isGlobalAdmin || isAnyTeamAdmin" class="mt-4">
             <SidebarGroupLabel v-if="sidebarOpen">Administration</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
                 <template v-for="item in adminNavItems" :key="item.title">
-                  <!-- Global admins see all items, team admins only see "Teams" -->
-                  <SidebarMenuItem v-if="authStore.user?.role === 'admin' || item.title === 'Teams'">
+                  <SidebarMenuItem v-if="isGlobalAdmin || item.title === 'Teams'">
                     <SidebarMenuButton asChild :tooltip="item.title"
                       class="hover:bg-primary hover:text-primary-foreground py-2 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground rounded-md transition-colors duration-150">
                       <router-link :to="item.url" class="flex items-center" active-class="font-medium">

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -119,13 +119,14 @@ const routes: RouteRecordRaw[] = [
     ],
   },
 
-  // Admin Section (Admin only)
+  // Admin Section. Per-route gates: `requiresAdmin` blocks non-global admins;
+  // `requiresAnyTeamAdmin` lets team admins through for their team's pages.
+  // The parent has no role meta — children declare their own access.
   {
     path: "/admin",
     component: lazy("AccessLayout", () => import("@/views/access/AccessLayout.vue")),
     meta: {
       requiresAuth: true,
-      requiresAdmin: true,
     },
     children: [
       {
@@ -136,19 +137,19 @@ const routes: RouteRecordRaw[] = [
         path: "users",
         name: "ManageUsers",
         component: lazy("UsersList", () => import("@/views/access/users/UsersList.vue")),
-        meta: { title: "Users" },
+        meta: { title: "Users", requiresAdmin: true },
       },
       {
         path: "teams",
         name: "Teams",
         component: lazy("TeamsList", () => import("@/views/access/teams/TeamsList.vue")),
-        meta: { title: "Teams" },
+        meta: { title: "Teams", requiresAnyTeamAdmin: true },
       },
       {
         path: "teams/:id",
         name: "TeamSettings",
         component: lazy("TeamSettings", () => import("@/views/access/teams/TeamSettings.vue")),
-        meta: { title: "Team Settings" },
+        meta: { title: "Team Settings", requiresAnyTeamAdmin: true },
       },
       {
         path: "sources",
@@ -270,6 +271,14 @@ router.beforeEach(async (to) => {
 
   if (to.matched.some((record) => record.meta.requiresAdmin) && !isAdmin) {
     return { name: "Forbidden" };
+  }
+
+  if (to.matched.some((record) => record.meta.requiresAnyTeamAdmin) && !isAdmin) {
+    // Lazy-import to avoid a circular store dependency at module init.
+    const { useTeamsStore } = await import("@/stores/teams");
+    if (!useTeamsStore().isAnyTeamAdmin) {
+      return { name: "Forbidden" };
+    }
   }
 
   if (isAuthenticated && !isPublic) {

--- a/frontend/src/views/collections/CollectionDetailView.vue
+++ b/frontend/src/views/collections/CollectionDetailView.vue
@@ -45,7 +45,7 @@ import { useToast } from "@/composables/useToast";
 import { TOAST_DURATION } from "@/lib/constants";
 import { useCollectionsStore } from "@/stores/collections";
 import { useAuthStore } from "@/stores/auth";
-import { useTeamsStore } from "@/stores/teams";
+import { useTeamPermissions } from "@/composables/useTeamPermissions";
 import { useUsersStore } from "@/stores/users";
 import {
   Select,
@@ -60,20 +60,20 @@ const router = useRouter();
 const { toast } = useToast();
 const store = useCollectionsStore();
 const authStore = useAuthStore();
-const teamsStore = useTeamsStore();
 const usersStore = useUsersStore();
 const { data } = storeToRefs(store);
+const { isAnyTeamAdmin, isGlobalAdmin, canManageCollection } = useTeamPermissions();
 
 const collectionID = computed(() => Number(route.params.collectionID));
 const collection = computed(() => store.collections.find((c) => c.id === collectionID.value) ?? null);
 const items = computed(() => data.value.items[collectionID.value] ?? []);
 const members = computed(() => data.value.members[collectionID.value] ?? []);
 
-const isOwner = computed(() => collection.value?.caller_role === "owner" || authStore.user?.role === "admin");
+const isOwner = computed(() => canManageCollection(collection.value));
 // Listing users (`/api/v1/users`) requires admin or any-team-admin. Hide the
 // invite UI from owners who lack that role since the dropdown can't be
 // populated without it.
-const canListUsers = computed(() => authStore.user?.role === "admin" || teamsStore.isAnyTeamAdmin);
+const canListUsers = computed(() => isGlobalAdmin.value || isAnyTeamAdmin.value);
 const canInviteMembers = computed(() => isOwner.value && canListUsers.value && !collection.value?.is_personal);
 
 const showAddMember = ref(false);

--- a/frontend/src/views/collections/CollectionsListView.vue
+++ b/frontend/src/views/collections/CollectionsListView.vue
@@ -16,6 +16,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useToast } from "@/composables/useToast";
+import { useTeamPermissions } from "@/composables/useTeamPermissions";
 import { TOAST_DURATION } from "@/lib/constants";
 import { useCollectionsStore } from "@/stores/collections";
 import type { Collection } from "@/api/collections";
@@ -23,6 +24,7 @@ import type { Collection } from "@/api/collections";
 const router = useRouter();
 const { toast } = useToast();
 const store = useCollectionsStore();
+const { isAnyTeamCollectionMutator } = useTeamPermissions();
 
 const showCreate = ref(false);
 const createName = ref("");
@@ -68,7 +70,7 @@ function viewCollection(collection: Collection) {
         <h1 class="text-lg font-semibold tracking-tight">Collections</h1>
         <p class="text-sm text-muted-foreground">Organize saved queries into shareable lists.</p>
       </div>
-      <Button size="sm" @click="showCreate = true">
+      <Button v-if="isAnyTeamCollectionMutator" size="sm" @click="showCreate = true">
         <Plus class="mr-1.5 h-3.5 w-3.5" />
         New
       </Button>

--- a/frontend/src/views/collections/SavedQueriesView.vue
+++ b/frontend/src/views/collections/SavedQueriesView.vue
@@ -62,7 +62,7 @@ const {
   editQuery,
   deleteQuery,
   clearSearch,
-  canManageCollections,
+  canEditQuery,
 } = useSavedQueries(localQueries);
 
 // Collection picker state: "all" or a numeric collection id
@@ -313,10 +313,10 @@ function manageCollection() {
                   <DropdownMenuItem @click="copyShareUrl(query)">
                     <Link class="mr-2 h-4 w-4" /> Copy Link
                   </DropdownMenuItem>
-                  <DropdownMenuItem v-if="canManageCollections" @click="editQuery(query)">
+                  <DropdownMenuItem v-if="canEditQuery(query)" @click="editQuery(query)">
                     <Pencil class="mr-2 h-4 w-4" /> Edit
                   </DropdownMenuItem>
-                  <DropdownMenuItem v-if="canManageCollections" @click="handleDeleteQuery(query)" class="text-destructive">
+                  <DropdownMenuItem v-if="canEditQuery(query)" @click="handleDeleteQuery(query)" class="text-destructive">
                     <Trash2 class="mr-2 h-4 w-4" /> Delete
                   </DropdownMenuItem>
                 </DropdownMenuContent>

--- a/internal/core/teams.go
+++ b/internal/core/teams.go
@@ -524,6 +524,40 @@ func IsAnyTeamAdmin(ctx context.Context, db *sqlite.DB, userID models.UserID) (b
 	return false, nil
 }
 
+// IsTeamCollectionMutator reports whether the user has the role required to
+// mutate shared resources (collections) in a specific team. Both team admins
+// and team editors qualify. The per-collection ownership check happens
+// separately in core/collections.go and is unaffected by this role gate.
+func IsTeamCollectionMutator(ctx context.Context, db *sqlite.DB, teamID models.TeamID, userID models.UserID) (bool, error) {
+	member, err := db.GetTeamMember(ctx, teamID, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("error checking team collection mutator status: %w", err)
+	}
+	if member == nil {
+		return false, nil
+	}
+	return member.Role == models.TeamRoleAdmin || member.Role == models.TeamRoleEditor, nil
+}
+
+// IsAnyTeamCollectionMutator reports whether the user is an admin or editor
+// in at least one team. Used as the coarse gate on collection mutation
+// endpoints — the per-collection owner check is enforced inside core.
+func IsAnyTeamCollectionMutator(ctx context.Context, db *sqlite.DB, userID models.UserID) (bool, error) {
+	teams, err := db.ListTeamsForUser(ctx, userID)
+	if err != nil {
+		return false, fmt.Errorf("error listing teams for user: %w", err)
+	}
+	for _, team := range teams {
+		if team.Role == string(models.TeamRoleAdmin) || team.Role == string(models.TeamRoleEditor) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // TeamHasSourceAccess checks if a specific team has access to a specific source.
 func TeamHasSourceAccess(ctx context.Context, db *sqlite.DB, teamID models.TeamID, sourceID models.SourceID) (bool, error) {
 	hasAccess, err := db.TeamHasSource(ctx, teamID, sourceID)

--- a/internal/core/teams_role_test.go
+++ b/internal/core/teams_role_test.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mr-karan/logchef/internal/sqlite"
+	"github.com/mr-karan/logchef/pkg/models"
+)
+
+// seedTeamWithMember creates a team and adds the given user with the given role,
+// returning the team id. Fails the test on any error so call sites stay flat.
+func seedTeamWithMember(t *testing.T, db *sqlite.DB, teamName, ownerEmail string, role models.TeamRole) (models.TeamID, models.UserID) {
+	t.Helper()
+	log := discardLogger()
+	user := newTestUser(t, db, ownerEmail, ownerEmail)
+	team, err := CreateTeam(context.Background(), db, log, teamName, "")
+	if err != nil {
+		t.Fatalf("CreateTeam(%q): %v", teamName, err)
+	}
+	if err := AddTeamMember(context.Background(), db, log, team.ID, user.ID, role); err != nil {
+		t.Fatalf("AddTeamMember(team=%d, user=%d, role=%s): %v", team.ID, user.ID, role, err)
+	}
+	return team.ID, user.ID
+}
+
+func TestIsTeamCollectionMutator(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	adminTeam, adminID := seedTeamWithMember(t, db, "admin-team", "admin@example.com", models.TeamRoleAdmin)
+	editorTeam, editorID := seedTeamWithMember(t, db, "editor-team", "editor@example.com", models.TeamRoleEditor)
+	memberTeam, memberID := seedTeamWithMember(t, db, "member-team", "member@example.com", models.TeamRoleMember)
+	stranger := newTestUser(t, db, "stranger@example.com", "Stranger")
+
+	cases := []struct {
+		name   string
+		teamID models.TeamID
+		userID models.UserID
+		want   bool
+	}{
+		{"admin is mutator", adminTeam, adminID, true},
+		{"editor is mutator", editorTeam, editorID, true},
+		{"member is not mutator", memberTeam, memberID, false},
+		{"non-member is not mutator", adminTeam, stranger.ID, false},
+		{"admin in team A not mutator in team B", editorTeam, adminID, false},
+		{"editor in team A not mutator in team B", adminTeam, editorID, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsTeamCollectionMutator(ctx, db, tc.teamID, tc.userID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("IsTeamCollectionMutator(team=%d, user=%d) = %v, want %v",
+					tc.teamID, tc.userID, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsAnyTeamCollectionMutator(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	_, adminID := seedTeamWithMember(t, db, "admin-team", "admin@example.com", models.TeamRoleAdmin)
+	_, editorID := seedTeamWithMember(t, db, "editor-team", "editor@example.com", models.TeamRoleEditor)
+	_, memberID := seedTeamWithMember(t, db, "member-team", "member@example.com", models.TeamRoleMember)
+	stranger := newTestUser(t, db, "stranger@example.com", "Stranger")
+
+	cases := []struct {
+		name   string
+		userID models.UserID
+		want   bool
+	}{
+		{"team admin", adminID, true},
+		{"team editor", editorID, true},
+		{"team member is not mutator", memberID, false},
+		{"user with no team", stranger.ID, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := IsAnyTeamCollectionMutator(ctx, db, tc.userID)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("IsAnyTeamCollectionMutator(user=%d) = %v, want %v",
+					tc.userID, got, tc.want)
+			}
+		})
+	}
+}
+
+// IsAnyTeamAdmin must NOT count editors. This guards against accidental
+// elevation if someone "fixes" IsAnyTeamAdmin to include editors, which would
+// silently leak team-admin endpoints (membership management, source linking)
+// to editors.
+func TestIsAnyTeamAdminExcludesEditors(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	_, editorID := seedTeamWithMember(t, db, "editor-team", "editor@example.com", models.TeamRoleEditor)
+	_, adminID := seedTeamWithMember(t, db, "admin-team", "admin@example.com", models.TeamRoleAdmin)
+
+	editorIsAdmin, err := IsAnyTeamAdmin(ctx, db, editorID)
+	if err != nil {
+		t.Fatalf("IsAnyTeamAdmin(editor): %v", err)
+	}
+	if editorIsAdmin {
+		t.Error("editor was reported as an admin — admin-only routes would leak")
+	}
+
+	adminIsAdmin, err := IsAnyTeamAdmin(ctx, db, adminID)
+	if err != nil {
+		t.Fatalf("IsAnyTeamAdmin(admin): %v", err)
+	}
+	if !adminIsAdmin {
+		t.Error("admin was not recognized as an admin")
+	}
+}
+
+// IsTeamAdmin must also remain strict: an editor in the team is not the admin
+// of that team.
+func TestIsTeamAdminStrict(t *testing.T) {
+	t.Parallel()
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	team, editorID := seedTeamWithMember(t, db, "team", "editor@example.com", models.TeamRoleEditor)
+
+	got, err := IsTeamAdmin(ctx, db, team, editorID)
+	if err != nil {
+		t.Fatalf("IsTeamAdmin: %v", err)
+	}
+	if got {
+		t.Error("editor was reported as team admin")
+	}
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -202,6 +202,37 @@ func (s *Server) requireUserNotManaged(c *fiber.Ctx) error {
 	return c.Next()
 }
 
+// requireAnyTeamCollectionMutator is middleware that admits the caller if they
+// are a global admin, an admin of any team, or an editor of any team. This is
+// the coarse gate for endpoints that mutate cross-team resources (collections).
+// The per-collection ownership check still runs inside core, so this only
+// rejects callers who can't legitimately attempt any collection mutation.
+// It assumes requireAuth has already run.
+func (s *Server) requireAnyTeamCollectionMutator(c *fiber.Ctx) error {
+	user, ok := c.Locals("user").(*models.User)
+	if !ok || user == nil {
+		s.log.Error("user not found in context for collection mutator check")
+		return SendErrorWithType(c, fiber.StatusUnauthorized, "Authentication context missing", models.AuthenticationErrorType)
+	}
+
+	if user.Role == models.UserRoleAdmin {
+		return c.Next()
+	}
+
+	isMutator, err := core.IsAnyTeamCollectionMutator(c.Context(), s.sqlite, user.ID)
+	if err != nil {
+		s.log.Error("failed to check collection mutator status", "error", err, "user_id", user.ID)
+		return SendError(c, fiber.StatusInternalServerError, "Failed to verify role")
+	}
+
+	if !isMutator {
+		s.log.Warn("User is not a collection mutator in any team", "user_id", user.ID)
+		return SendErrorWithType(c, fiber.StatusForbidden, "Team admin or editor role required", models.AuthorizationErrorType)
+	}
+
+	return c.Next()
+}
+
 // requireAnyTeamAdmin is middleware that ensures the authenticated user is an admin of at least one team,
 // or is a global admin. This is used for endpoints that should be accessible to team admins
 // without requiring a specific team context (e.g., listing users to add to teams).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -228,14 +228,15 @@ func (s *Server) setupRoutes() {
 	collections.Get("/:collectionID", s.handleGetCollection)
 	collections.Get("/:collectionID/members", s.handleListCollectionMembers)
 	collections.Get("/:collectionID/items", s.handleListCollectionItems)
-	// Mutations require team admin/editor or global admin
-	collections.Post("/", s.requireAnyTeamAdmin, s.handleCreateCollection)
-	collections.Put("/:collectionID", s.requireAnyTeamAdmin, s.handleUpdateCollection)
-	collections.Delete("/:collectionID", s.requireAnyTeamAdmin, s.handleDeleteCollection)
-	collections.Post("/:collectionID/members", s.requireAnyTeamAdmin, s.handleAddCollectionMember)
-	collections.Delete("/:collectionID/members/:userID", s.requireAnyTeamAdmin, s.handleRemoveCollectionMember)
-	collections.Post("/:collectionID/items", s.requireAnyTeamAdmin, s.handleAddCollectionItem)
-	collections.Delete("/:collectionID/items/:queryID", s.requireAnyTeamAdmin, s.handleRemoveCollectionItem)
+	// Coarse gate: caller must be admin/editor in at least one team (or global admin).
+	// Per-collection ownership is enforced separately inside core/collections.go.
+	collections.Post("/", s.requireAnyTeamCollectionMutator, s.handleCreateCollection)
+	collections.Put("/:collectionID", s.requireAnyTeamCollectionMutator, s.handleUpdateCollection)
+	collections.Delete("/:collectionID", s.requireAnyTeamCollectionMutator, s.handleDeleteCollection)
+	collections.Post("/:collectionID/members", s.requireAnyTeamCollectionMutator, s.handleAddCollectionMember)
+	collections.Delete("/:collectionID/members/:userID", s.requireAnyTeamCollectionMutator, s.handleRemoveCollectionMember)
+	collections.Post("/:collectionID/items", s.requireAnyTeamCollectionMutator, s.handleAddCollectionItem)
+	collections.Delete("/:collectionID/items/:queryID", s.requireAnyTeamCollectionMutator, s.handleRemoveCollectionItem)
 
 	// Saved Queries (cross-team, source-scoped). Visibility: any user with source
 	// access via any team. Edit/delete: creator + global admin (legacy queries


### PR DESCRIPTION
Editors couldn't create saved queries even
though that's the role's stated purpose. Audit (with help from Codex)
turned up a broader pattern — the Editor role was added without rewiring
the gates that pre-dated it, and the recent UI consistency PR
accidentally locked team admins out of `/admin/teams`.

## Role contract (authoritative)

See `.plans/spec_roles_consistency.md` for the full matrix. Highlights:

| Action | global | team admin | team editor | team member |
|---|---|---|---|---|
| Create saved query | ✅ | ✅ | ✅ | ✅ |
| Edit/delete own saved query | ✅ | own | own | own |
| Create collection | ✅ | ✅ | ✅ | ❌ |
| Manage own collection (rename, invite, pin) | own | own | own | ❌ |
| Add/remove team member | ✅ | ✅ | ❌ | ❌ |
| Link/unlink source to team | ✅ | ✅ | ❌ | ❌ |
| Create source / user / system settings | ✅ | ❌ | ❌ | ❌ |

## Changes

### Backend
- New `core.IsTeamCollectionMutator` + `core.IsAnyTeamCollectionMutator`
- New `requireAnyTeamCollectionMutator` middleware (admits admin + editor)
- 7 collection routes in `server.go` now use the new middleware. Team
  admin routes (membership management, source linking) stay strict on
  `requireAnyTeamAdmin`.

### Frontend
- New `useTeamPermissions()` composable — single source of truth for
  every role gate.
- Router: `/admin` parent no longer requires global admin. Per-route
  gates with a new `requiresAnyTeamAdmin` meta flag for `/admin/teams`
  and `/admin/teams/:id`.
- Save button (Explore + dropdown) gated on `canSaveQuery` (any team
  member). Edit/Delete on saved-query rows gated on `canEditQuery(query)`
  (creator + global admin).
- Collections list "New" button gated on `isAnyTeamCollectionMutator`.
- Add-to-Collection drawer filters listed collections to ones the
  caller owns.
- Collection detail view's `isOwner` / `canListUsers` switched to the
  composable's APIs.

### Tests
- **Backend** (`internal/core/teams_role_test.go`, 18 cases): admin /
  editor / member / non-member / cross-team matrix for the new helpers,
  plus regression guards on `IsAnyTeamAdmin` and `IsTeamAdmin` to ensure
  they stay strict (editors must not silently elevate to admin).
- **Frontend** (`composables/__tests__/useTeamPermissions.test.ts`, 28
  cases): every computed and method in the role matrix, including
  legacy NULL-creator saved-query handling and global-admin overrides.

## Verify locally

1. **Editor** team role can save a query, pin to their personal
   collection, edit/delete their own queries, create a shared
   collection, but cannot reach `/admin/users` or invite team members.
2. **Member** can save queries, edit/delete own. Cannot create
   collections; "New" button is hidden. Cannot pin to shared
   collections they don't own.
3. **Team admin** (non-global) can reach `/admin/teams` and
   `/admin/teams/<their-team>` — this was broken on `main` after the
   previous /admin/* route rename.
4. **Global admin** sees everything as before.

Spec: `.plans/spec_roles_consistency.md`
Audit: Codex helped me match the design against the actual gates; PR
implements the gaps in one pass.

Draft so you can review before merge.