### PR TITLE
feat(alerts): honor alerts.enabled end-to-end

### DIFF
--- a/frontend/src/api/meta.ts
+++ b/frontend/src/api/meta.ts
@@ -8,6 +8,9 @@ export interface MetaResponse {
   default_preview_limit?: number;
   max_preview_limit?: number;
   max_export_rows?: number;
+  // Optional so a stale server without the field is treated as "enabled" by
+  // the store default — preserves backwards compatibility.
+  alerts_enabled?: boolean;
 }
 
 export const metaApi = {

--- a/frontend/src/layouts/InnerApp.vue
+++ b/frontend/src/layouts/InnerApp.vue
@@ -59,7 +59,7 @@ import { useTeamPermissions } from "@/composables/useTeamPermissions";
 import { useThemeStore, type ThemeMode } from "@/stores/theme";
 import { usePreferencesStore } from "@/stores/preferences";
 import { useMetaStore } from "@/stores/meta";
-import { ref, watch, onMounted } from "vue";
+import { ref, watch, onMounted, computed } from "vue";
 import { useTeamsStore } from "@/stores/teams";
 import { useExploreStore } from "@/stores/explore";
 
@@ -140,8 +140,9 @@ interface NavItem {
   adminOnly?: boolean;
 }
 
-// Group navigation items by category
-const mainNavItems: NavItem[] = [
+// Group navigation items by category. Filtered so the Alerts entry drops out
+// when the server advertises `alerts_enabled: false` via /api/v1/meta.
+const allMainNavItems: NavItem[] = [
   {
     title: "Explorer",
     icon: Search,
@@ -158,6 +159,10 @@ const mainNavItems: NavItem[] = [
     url: "/logs/alerts",
   },
 ];
+
+const mainNavItems = computed(() =>
+  allMainNavItems.filter((item) => item.url !== "/logs/alerts" || metaStore.alertsEnabled)
+);
 
 const adminNavItems: NavItem[] = [
   {

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -4,6 +4,7 @@ import {
   type RouteRecordRaw,
 } from "vue-router";
 import { useAuthStore } from "@/stores/auth";
+import { useMetaStore } from "@/stores/meta";
 import { error } from "@/utils/debug";
 import { contextRouterGuard } from "./contextGuard";
 import ComponentLoadError from "@/views/error/ComponentLoadError.vue";
@@ -266,6 +267,14 @@ router.beforeEach(async (to) => {
       query: {},
       replace: true,
     };
+  }
+
+  // If the server has alerting disabled, redirect any /logs/alerts* deep link
+  // to the explorer. The layered defenses in each alert view and the alert
+  // stores handle bookmarked URLs that arrive before meta has loaded.
+  const metaStore = useMetaStore();
+  if (!metaStore.alertsEnabled && to.path.startsWith("/logs/alerts")) {
+    return { path: "/logs/explore" };
   }
 
   if (to.matched.some((record) => record.meta.requiresAdmin) && !isAdmin) {

--- a/frontend/src/stores/__tests__/meta.test.ts
+++ b/frontend/src/stores/__tests__/meta.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useMetaStore } from '../meta'
+
+// Mock the meta API so we can drive the store from different server responses.
+vi.mock('@/api/meta', () => ({
+  metaApi: {
+    getMeta: vi.fn(),
+  },
+}))
+
+// Silence the toast side-effect via useToast when errors happen.
+vi.mock('@/composables/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+import { metaApi } from '@/api/meta'
+
+// apiClient wraps every response in { status, data } — useApiQuery keys off
+// `status === "success"`. Build fake responses in that shape so the store's
+// onSuccess handler runs end-to-end.
+const okResponse = (overrides: Record<string, unknown> = {}) => ({
+  status: 'success' as const,
+  data: {
+    version: '0.0.0-test',
+    http_server_timeout: '30s',
+    max_query_limit: 100000,
+    max_query_timeout_seconds: 120,
+    default_preview_limit: 1000,
+    max_preview_limit: 100000,
+    max_export_rows: 1000000,
+    ...overrides,
+  },
+})
+
+describe('useMetaStore alertsEnabled capability', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('defaults alertsEnabled to true before loadMeta runs', () => {
+    const store = useMetaStore()
+    expect(store.alertsEnabled).toBe(true)
+  })
+
+  it('defaults alertsEnabled to true when the field is absent from the API response (older server)', async () => {
+    ;(metaApi.getMeta as any).mockResolvedValueOnce(okResponse())
+
+    const store = useMetaStore()
+    await store.loadMeta()
+
+    expect(store.isInitialized).toBe(true)
+    expect(store.alertsEnabled).toBe(true)
+  })
+
+  it('reflects alerts_enabled=false when the API says so', async () => {
+    ;(metaApi.getMeta as any).mockResolvedValueOnce(okResponse({ alerts_enabled: false }))
+
+    const store = useMetaStore()
+    await store.loadMeta()
+
+    expect(store.isInitialized).toBe(true)
+    expect(store.alertsEnabled).toBe(false)
+  })
+
+  it('reflects alerts_enabled=true when the API explicitly says so', async () => {
+    ;(metaApi.getMeta as any).mockResolvedValueOnce(okResponse({ alerts_enabled: true }))
+
+    const store = useMetaStore()
+    await store.loadMeta()
+
+    expect(store.alertsEnabled).toBe(true)
+  })
+})

--- a/frontend/src/stores/alertHistory.ts
+++ b/frontend/src/stores/alertHistory.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia";
 import { alertsApi, type AlertHistoryEntry, type ResolveAlertRequest } from "@/api/alerts";
 import { useBaseStore } from "./base";
 import { useContextStore } from "./context";
+import { useMetaStore } from "./meta";
 import type { APIErrorResponse } from "@/api/types";
 
 interface AlertHistoryState {
@@ -35,7 +36,14 @@ export const useAlertHistoryStore = defineStore("alertHistory", () => {
     state.data.value.limit = limit > 0 ? limit : state.data.value.limit;
   }
 
+  // Belt-and-braces: match the guard in useAlertsStore so that a stale
+  // bookmarked URL bypassing the router guard cannot fire alert HTTP.
+  function alertsDisabledResult() {
+    return { success: false as const, data: null };
+  }
+
   async function loadHistory(alertId: number, _teamId?: number | null, _sourceId?: number | null, limit?: number) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     setCurrentContext(alertId);
     const effectiveLimit = limit ?? state.data.value.limit;
     return await state.withLoading(`loadHistory-${alertId}`, async () => {
@@ -65,6 +73,7 @@ export const useAlertHistoryStore = defineStore("alertHistory", () => {
   }
 
   async function resolveAlert(_teamId: number | undefined, _sourceId: number | undefined, alertId: number, payload: ResolveAlertRequest) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     return await state.withLoading(`resolveAlert-${alertId}`, async () => {
       return await state.callApi<{ message: string }>({
         apiCall: () => alertsApi.resolve(alertId, payload),

--- a/frontend/src/stores/alerts.ts
+++ b/frontend/src/stores/alerts.ts
@@ -3,6 +3,7 @@ import { defineStore } from "pinia";
 import { alertsApi, type Alert, type CreateAlertRequest, type UpdateAlertRequest } from "@/api/alerts";
 import { useBaseStore } from "./base";
 import { useContextStore } from "./context";
+import { useMetaStore } from "./meta";
 
 interface AlertsState {
   alerts: Alert[];
@@ -47,7 +48,15 @@ export const useAlertsStore = defineStore("alerts", () => {
     state.data.value.selectedAlertId = null;
   }
 
+  // Belt-and-braces: even if the router guard is bypassed (bookmarked URL
+  // hitting the view before meta has loaded, or a devtools call), stop
+  // firing alert HTTP when the server advertises alerts as disabled.
+  function alertsDisabledResult() {
+    return { success: false as const, data: null };
+  }
+
   async function fetchAlerts(_teamId?: number | undefined, sourceId?: number) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     const key = sourceId ? `fetchAlerts-${sourceId}` : 'fetchAlerts-all';
     return await state.withLoading(key, async () => {
       return await state.callApi<Alert[]>({
@@ -88,6 +97,7 @@ export const useAlertsStore = defineStore("alerts", () => {
   }
 
   async function createAlert(_teamId: number | undefined, sourceId: number, payload: Omit<CreateAlertRequest, "source_id">) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     return await state.withLoading("createAlert", async () => {
       return await state.callApi<Alert>({
         apiCall: () => alertsApi.create({ ...payload, source_id: sourceId }),
@@ -104,6 +114,7 @@ export const useAlertsStore = defineStore("alerts", () => {
   }
 
   async function updateAlert(_teamId: number | undefined, _sourceId: number | undefined, alertId: number, payload: UpdateAlertRequest) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     return await state.withLoading(`updateAlert-${alertId}`, async () => {
       return await state.callApi<Alert>({
         apiCall: () => alertsApi.update(alertId, payload),
@@ -119,6 +130,7 @@ export const useAlertsStore = defineStore("alerts", () => {
   }
 
   async function deleteAlert(_teamId: number | undefined, _sourceId: number | undefined, alertId: number) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     return await state.withLoading(`deleteAlert-${alertId}`, async () => {
       return await state.callApi<{ message: string }>({
         apiCall: () => alertsApi.delete(alertId),
@@ -132,6 +144,7 @@ export const useAlertsStore = defineStore("alerts", () => {
   }
 
   async function refreshAlert(_teamId: number | undefined, _sourceId: number | undefined, alertId: number) {
+    if (!useMetaStore().alertsEnabled) return alertsDisabledResult();
     return await state.withLoading(`refreshAlert-${alertId}`, async () => {
       return await state.callApi<Alert>({
         apiCall: () => alertsApi.get(alertId),

--- a/frontend/src/stores/meta.ts
+++ b/frontend/src/stores/meta.ts
@@ -12,6 +12,7 @@ interface MetaState {
   defaultPreviewLimit: number;
   maxPreviewLimit: number;
   maxExportRows: number;
+  alertsEnabled: boolean;
   isInitialized: boolean;
 }
 
@@ -24,6 +25,9 @@ export const useMetaStore = defineStore("meta", () => {
     defaultPreviewLimit: 1000,
     maxPreviewLimit: 100000,
     maxExportRows: 1000000,
+    // Default true so an older server that doesn't advertise the field
+    // keeps working; disabling is an opt-in signalled by the server.
+    alertsEnabled: true,
     isInitialized: false,
   });
 
@@ -35,6 +39,7 @@ export const useMetaStore = defineStore("meta", () => {
   const defaultPreviewLimit = computed(() => state.data.value.defaultPreviewLimit);
   const maxPreviewLimit = computed(() => state.data.value.maxPreviewLimit);
   const maxExportRows = computed(() => state.data.value.maxExportRows);
+  const alertsEnabled = computed(() => state.data.value.alertsEnabled);
   const isInitialized = computed(() => state.data.value.isInitialized);
   const error = computed(() => state.error.value);
 
@@ -59,6 +64,7 @@ export const useMetaStore = defineStore("meta", () => {
               state.data.value.defaultPreviewLimit = response.default_preview_limit ?? response.max_query_limit;
               state.data.value.maxPreviewLimit = response.max_preview_limit ?? response.max_query_limit;
               state.data.value.maxExportRows = response.max_export_rows ?? 1000000;
+              state.data.value.alertsEnabled = response.alerts_enabled ?? true;
               state.data.value.isInitialized = true;
             }
           },
@@ -83,6 +89,7 @@ export const useMetaStore = defineStore("meta", () => {
     state.data.value.defaultPreviewLimit = 1000;
     state.data.value.maxPreviewLimit = 100000;
     state.data.value.maxExportRows = 1000000;
+    state.data.value.alertsEnabled = true;
     state.data.value.isInitialized = false;
   }
 
@@ -94,6 +101,7 @@ export const useMetaStore = defineStore("meta", () => {
     defaultPreviewLimit,
     maxPreviewLimit,
     maxExportRows,
+    alertsEnabled,
     isInitialized,
     error,
     loadMeta,

--- a/frontend/src/views/admin/AdminSettings.vue
+++ b/frontend/src/views/admin/AdminSettings.vue
@@ -33,12 +33,14 @@ import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
 import { useSettingsStore } from '@/stores/settings'
 import { useAuthStore } from '@/stores/auth'
+import { useMetaStore } from '@/stores/meta'
 import type { SystemSetting, UpdateSettingRequest } from '@/api/settings'
 import { useToast } from '@/composables/useToast'
 
 const { toast } = useToast()
 
 const authStore = useAuthStore()
+const metaStore = useMetaStore()
 
 const settingsStore = useSettingsStore()
 const { isLoading } = storeToRefs(settingsStore)
@@ -50,7 +52,9 @@ const showTestWebhookDialog = ref(false)
 const settingToEdit = ref<SystemSetting | null>(null)
 const settingToDelete = ref<SystemSetting | null>(null)
 const showSensitiveValues = ref<Record<string, boolean>>({})
-const currentTab = ref('alerts')
+// Default to Alerts unless the server has disabled alerting; in that case
+// fall back to AI so an admin isn't landed on a hidden tab.
+const currentTab = ref(metaStore.alertsEnabled ? 'alerts' : 'ai')
 const testEmailRecipient = ref('')
 const testWebhookUrl = ref('')
 const isTestingEmail = ref(false)
@@ -197,14 +201,14 @@ onMounted(() => {
     <LoadingState v-if="isLoading" label="Loading settings…" />
     <Tabs v-else v-model="currentTab" class="w-full">
           <TabsList>
-            <TabsTrigger value="alerts">Alerts</TabsTrigger>
+            <TabsTrigger v-if="metaStore.alertsEnabled" value="alerts">Alerts</TabsTrigger>
             <TabsTrigger value="ai">AI</TabsTrigger>
             <TabsTrigger value="auth">Authentication</TabsTrigger>
             <TabsTrigger value="server">Server</TabsTrigger>
           </TabsList>
 
           <!-- Alerts Tab -->
-          <TabsContent value="alerts" class="space-y-4">
+          <TabsContent v-if="metaStore.alertsEnabled" value="alerts" class="space-y-4">
             <div class="flex items-center justify-between">
               <div class="text-sm text-muted-foreground">
                 {{ getCategoryDescription('alerts') }}

--- a/frontend/src/views/alerts/AlertCreate.vue
+++ b/frontend/src/views/alerts/AlertCreate.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { Bell } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import AlertForm from "@/components/alerts/AlertForm.vue";
+import EmptyState from "@/components/layout/EmptyState.vue";
 import TeamSourceSelector from "@/views/explore/components/TeamSourceSelector.vue";
 import { useAlertsStore } from "@/stores/alerts";
 import { useContextStore } from "@/stores/context";
+import { useMetaStore } from "@/stores/meta";
 import { useSourcesStore } from "@/stores/sources";
 import type { Alert, CreateAlertRequest } from "@/api/alerts";
 
@@ -14,6 +17,7 @@ const router = useRouter();
 const route = useRoute();
 const alertsStore = useAlertsStore();
 const contextStore = useContextStore();
+const metaStore = useMetaStore();
 const sourcesStore = useSourcesStore();
 
 const currentTeamId = computed(() => contextStore.teamId);
@@ -94,7 +98,13 @@ function handleCancel() {
 </script>
 
 <template>
-  <div class="space-y-6">
+  <EmptyState
+    v-if="!metaStore.alertsEnabled"
+    :icon="Bell"
+    title="Alerting is disabled"
+    description="Alerting is disabled on this server. Ask your administrator to set alerts.enabled = true and restart the server to enable."
+  />
+  <div v-else class="space-y-6">
     <div class="flex items-start justify-between gap-4">
       <div class="space-y-1">
         <h1 class="text-2xl font-semibold tracking-tight">

--- a/frontend/src/views/alerts/AlertDetail.vue
+++ b/frontend/src/views/alerts/AlertDetail.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { ArrowLeft, Trash2, CheckCircle2, AlertCircle, AlertTriangle, Clock, History } from "lucide-vue-next";
+import { ArrowLeft, Bell, Trash2, CheckCircle2, AlertCircle, AlertTriangle, Clock, History } from "lucide-vue-next";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -19,7 +19,9 @@ import {
 import { useAlertsStore } from "@/stores/alerts";
 import { useAlertHistoryStore } from "@/stores/alertHistory";
 import { useContextStore } from "@/stores/context";
+import { useMetaStore } from "@/stores/meta";
 import AlertForm from "@/components/alerts/AlertForm.vue";
+import EmptyState from "@/components/layout/EmptyState.vue";
 import type { Alert, UpdateAlertRequest } from "@/api/alerts";
 
 const route = useRoute();
@@ -28,6 +30,7 @@ const router = useRouter();
 const alertsStore = useAlertsStore();
 const alertHistoryStore = useAlertHistoryStore();
 const contextStore = useContextStore();
+const metaStore = useMetaStore();
 
 const alertId = computed(() => Number(route.params.alertID));
 const currentTab = ref<"edit" | "history">("edit");
@@ -125,7 +128,13 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="space-y-6">
+  <EmptyState
+    v-if="!metaStore.alertsEnabled"
+    :icon="Bell"
+    title="Alerting is disabled"
+    description="Alerting is disabled on this server. Ask your administrator to set alerts.enabled = true and restart the server to enable."
+  />
+  <div v-else class="space-y-6">
     <!-- Header Section -->
     <div class="flex items-start justify-between gap-4">
       <div class="flex items-start gap-3">

--- a/frontend/src/views/alerts/AlertsOverview.vue
+++ b/frontend/src/views/alerts/AlertsOverview.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { storeToRefs } from "pinia";
 import {
+  Bell,
   BellRing,
   Clock3,
   Copy,
@@ -43,9 +44,11 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import ErrorAlert from "@/components/ui/ErrorAlert.vue";
+import EmptyState from "@/components/layout/EmptyState.vue";
 import TeamSourceSelector from "@/views/explore/components/TeamSourceSelector.vue";
 import { useAlertsStore } from "@/stores/alerts";
 import { useContextStore } from "@/stores/context";
+import { useMetaStore } from "@/stores/meta";
 import { useContextSync } from "@/composables/useContextSync";
 import type { Alert } from "@/api/alerts";
 
@@ -54,6 +57,7 @@ const route = useRoute();
 
 const alertsStore = useAlertsStore();
 const contextStore = useContextStore();
+const metaStore = useMetaStore();
 
 const { initialize: initializeContext } = useContextSync({ basePath: '/logs/alerts' });
 
@@ -246,7 +250,13 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div class="space-y-6">
+  <EmptyState
+    v-if="!metaStore.alertsEnabled"
+    :icon="Bell"
+    title="Alerting is disabled"
+    description="Alerting is disabled on this server. Ask your administrator to set alerts.enabled = true and restart the server to enable."
+  />
+  <div v-else class="space-y-6">
     <div class="flex items-start justify-between gap-4">
       <div class="space-y-1">
         <h1 class="text-2xl font-semibold tracking-tight">Alert Rules</h1>

--- a/internal/server/admin_settings_handlers.go
+++ b/internal/server/admin_settings_handlers.go
@@ -340,6 +340,9 @@ func (s *Server) loadSMTPConfig(ctx context.Context) alerts.EmailSenderOptions {
 // handleTestEmail sends a test email to verify SMTP configuration.
 // POST /api/v1/admin/settings/test-email
 func (s *Server) handleTestEmail(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	// Get current user for default recipient and audit log
 	user, ok := c.Locals("user").(*models.User)
 	if !ok || user == nil {
@@ -409,6 +412,9 @@ func (s *Server) handleTestEmail(c *fiber.Ctx) error {
 // handleTestWebhook sends a test webhook to verify webhook configuration.
 // POST /api/v1/admin/settings/test-webhook
 func (s *Server) handleTestWebhook(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	// Get current user for audit log
 	user, ok := c.Locals("user").(*models.User)
 	if !ok || user == nil {

--- a/internal/server/alert_handlers.go
+++ b/internal/server/alert_handlers.go
@@ -3,6 +3,7 @@ package server
 import (
 	"database/sql"
 	"errors"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -12,6 +13,22 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 )
+
+// validateAlertsEnabled returns a handler-shaped error responder when the
+// alerts subsystem is disabled in config, or nil when it is enabled.
+// Mirrors validateAIConfig in logs_handlers.go. The flag is read once from
+// the config snapshot at request time; enabling or disabling alerts requires
+// a server restart.
+func (s *Server) validateAlertsEnabled() func(*fiber.Ctx) error {
+	if !s.config.Alerts.Enabled {
+		return func(c *fiber.Ctx) error {
+			return SendErrorWithType(c, http.StatusServiceUnavailable,
+				"Alerting is disabled on this server. Set alerts.enabled = true (or LOGCHEF_ALERTS__ENABLED=true) and restart to enable.",
+				models.GeneralErrorType)
+		}
+	}
+	return nil
+}
 
 func parseAlertID(c *fiber.Ctx) (models.AlertID, error) {
 	id, err := parsePositiveIntParam(c, "alertID")
@@ -58,6 +75,9 @@ func (s *Server) loadAlertWithVisibility(c *fiber.Ctx) (*models.Alert, *models.U
 
 // handleListAlerts lists alerts the caller can see. Optional ?source_id filter.
 func (s *Server) handleListAlerts(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	user := c.Locals("user").(*models.User)
 
 	if sourceParam := c.Query("source_id"); sourceParam != "" {
@@ -89,6 +109,9 @@ func (s *Server) handleListAlerts(c *fiber.Ctx) error {
 // handleCreateAlert creates a new alert against the source in the request body.
 // The caller must have source access; the resulting alert is owned by the caller.
 func (s *Server) handleCreateAlert(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	user := c.Locals("user").(*models.User)
 
 	var req models.CreateAlertRequest
@@ -127,6 +150,9 @@ func (s *Server) handleCreateAlert(c *fiber.Ctx) error {
 
 // handleGetAlert returns a single alert.
 func (s *Server) handleGetAlert(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	alert, _, err := s.loadAlertWithVisibility(c)
 	if err != nil {
 		return err
@@ -136,6 +162,9 @@ func (s *Server) handleGetAlert(c *fiber.Ctx) error {
 
 // handleUpdateAlert updates an alert. Allowed only for the creator or a global admin.
 func (s *Server) handleUpdateAlert(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	alert, user, err := s.loadAlertWithVisibility(c)
 	if err != nil {
 		return err
@@ -166,6 +195,9 @@ func (s *Server) handleUpdateAlert(c *fiber.Ctx) error {
 
 // handleDeleteAlert removes an alert (creator + global admin only).
 func (s *Server) handleDeleteAlert(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	alert, user, err := s.loadAlertWithVisibility(c)
 	if err != nil {
 		return err
@@ -185,6 +217,9 @@ func (s *Server) handleDeleteAlert(c *fiber.Ctx) error {
 
 // handleResolveAlert manually resolves the most recent triggered history entry.
 func (s *Server) handleResolveAlert(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	alert, user, err := s.loadAlertWithVisibility(c)
 	if err != nil {
 		return err
@@ -219,6 +254,9 @@ func (s *Server) handleResolveAlert(c *fiber.Ctx) error {
 
 // handleListAlertHistory returns recent history entries for an alert.
 func (s *Server) handleListAlertHistory(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	alert, _, err := s.loadAlertWithVisibility(c)
 	if err != nil {
 		return err
@@ -246,6 +284,9 @@ func (s *Server) handleListAlertHistory(c *fiber.Ctx) error {
 
 // handleTestAlertQuery executes a test query against the source in the request body.
 func (s *Server) handleTestAlertQuery(c *fiber.Ctx) error {
+	if err := s.validateAlertsEnabled(); err != nil {
+		return err(c)
+	}
 	user := c.Locals("user").(*models.User)
 
 	var req struct {

--- a/internal/server/alert_handlers_test.go
+++ b/internal/server/alert_handlers_test.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/mr-karan/logchef/internal/config"
+)
+
+func TestValidateAlertsEnabled(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enabled returns nil", func(t *testing.T) {
+		t.Parallel()
+		s := &Server{config: &config.Config{Alerts: config.AlertsConfig{Enabled: true}}}
+		if got := s.validateAlertsEnabled(); got != nil {
+			t.Fatalf("validateAlertsEnabled() = non-nil (%T), want nil", got)
+		}
+	})
+
+	t.Run("disabled returns 503 responder", func(t *testing.T) {
+		t.Parallel()
+		s := &Server{config: &config.Config{Alerts: config.AlertsConfig{Enabled: false}}}
+		responder := s.validateAlertsEnabled()
+		if responder == nil {
+			t.Fatalf("validateAlertsEnabled() = nil, want non-nil responder")
+		}
+
+		app := fiber.New()
+		app.Get("/probe", func(c *fiber.Ctx) error {
+			return responder(c)
+		})
+
+		resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/probe", nil))
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusServiceUnavailable)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		var envelope struct {
+			Status  string `json:"status"`
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			t.Fatalf("unmarshal body: %v (body=%q)", err, body)
+		}
+		if envelope.Status != "error" {
+			t.Fatalf("status = %q, want %q", envelope.Status, "error")
+		}
+		if !strings.Contains(envelope.Message, "alerts.enabled") {
+			t.Fatalf("message = %q, want it to reference alerts.enabled", envelope.Message)
+		}
+		if !strings.Contains(envelope.Message, "LOGCHEF_ALERTS__ENABLED") {
+			t.Fatalf("message = %q, want it to reference LOGCHEF_ALERTS__ENABLED", envelope.Message)
+		}
+	})
+}

--- a/internal/server/meta_handlers.go
+++ b/internal/server/meta_handlers.go
@@ -17,6 +17,7 @@ type MetaResponse struct {
 	DefaultPreviewLimit int    `json:"default_preview_limit"`
 	MaxPreviewLimit     int    `json:"max_preview_limit"`
 	MaxExportRows       int    `json:"max_export_rows"`
+	AlertsEnabled       bool   `json:"alerts_enabled"`
 }
 
 // handleGetMeta returns server metadata including version and configuration
@@ -38,6 +39,7 @@ func (s *Server) handleGetMeta(c *fiber.Ctx) error {
 		DefaultPreviewLimit: s.config.Query.DefaultPreviewLimit,
 		MaxPreviewLimit:     s.config.Query.MaxPreviewLimit,
 		MaxExportRows:       s.config.Export.MaxRows,
+		AlertsEnabled:       s.config.Alerts.Enabled,
 	}
 
 	if s.oidcProvider != nil {

--- a/internal/server/meta_handlers_test.go
+++ b/internal/server/meta_handlers_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+
+	"github.com/mr-karan/logchef/internal/config"
+)
+
+func TestHandleGetMetaAlertsEnabled(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		enabled bool
+	}{
+		{name: "alerts enabled", enabled: true},
+		{name: "alerts disabled", enabled: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &Server{
+				version: "test",
+				config: &config.Config{
+					Server: config.ServerConfig{HTTPServerTimeout: 30 * time.Second},
+					Alerts: config.AlertsConfig{Enabled: tc.enabled},
+				},
+			}
+
+			app := fiber.New()
+			app.Get("/api/v1/meta", s.handleGetMeta)
+
+			resp, err := app.Test(httptest.NewRequest(http.MethodGet, "/api/v1/meta", nil))
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+
+			// Assert the raw JSON key so the field name in the wire format
+			// is validated, not just the Go struct decoding.
+			var raw map[string]json.RawMessage
+			if err := json.Unmarshal(body, &raw); err != nil {
+				t.Fatalf("unmarshal envelope: %v (body=%q)", err, body)
+			}
+			dataRaw, ok := raw["data"]
+			if !ok {
+				t.Fatalf("response missing data field: %q", body)
+			}
+			var data map[string]json.RawMessage
+			if err := json.Unmarshal(dataRaw, &data); err != nil {
+				t.Fatalf("unmarshal data: %v (data=%q)", err, dataRaw)
+			}
+			ae, ok := data["alerts_enabled"]
+			if !ok {
+				t.Fatalf("data missing alerts_enabled field: %q", dataRaw)
+			}
+			var got bool
+			if err := json.Unmarshal(ae, &got); err != nil {
+				t.Fatalf("unmarshal alerts_enabled: %v", err)
+			}
+			if got != tc.enabled {
+				t.Fatalf("alerts_enabled = %v, want %v", got, tc.enabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Setting alerts.enabled = false previously only stopped the scheduler; the API, admin test endpoints, and UI stayed live.

- Advertise alerts_enabled on /api/v1/meta.
- Guard all 8 alert routes + admin test-email/test-webhook with a 503 handler (mirrors validateAIConfig).
- Frontend: filter sidebar, redirect /logs/alerts*, render EmptyState on alert views, hide Admin > System Settings > Alerts tab.
- Runtime stays restart-required to match the AI subsystem.

Refs: #97