### PR TITLE
fix(clickhouse): validate identifier names before interpolating into queries

### DIFF
--- a/internal/clickhouse/field_values.go
+++ b/internal/clickhouse/field_values.go
@@ -63,6 +63,12 @@ func buildLogchefQLConditionsSQL(query string) string {
 // GetFieldDistinctValues retrieves the top N distinct values for a field within a time range.
 func (c *Client) GetFieldDistinctValues(ctx context.Context, database, table string, params FieldValuesParams) (*FieldValuesResult, error) {
 	// Validate inputs that will be interpolated into SQL
+	if err := ValidateIdentifier(database); err != nil {
+		return nil, fmt.Errorf("invalid database name: %w", err)
+	}
+	if err := ValidateIdentifier(table); err != nil {
+		return nil, fmt.Errorf("invalid table name: %w", err)
+	}
 	if err := ValidateIdentifier(params.FieldName); err != nil {
 		return nil, fmt.Errorf("invalid field name: %w", err)
 	}
@@ -86,6 +92,8 @@ func (c *Client) GetFieldDistinctValues(ctx context.Context, database, table str
 	additionalConditions := buildLogchefQLConditionsSQL(params.LogchefQL)
 
 	quotedField := quoteIdentifier(params.FieldName)
+	quotedTS := quoteIdentifier(params.TimestampField)
+	qualifiedTable := fmt.Sprintf("%s.%s", quoteIdentifier(database), quoteIdentifier(table))
 
 	// For string-like fields, exclude empty strings. For numeric fields, no such filter.
 	emptyFilter := fmt.Sprintf("%s != ''", quotedField)
@@ -95,12 +103,12 @@ func (c *Client) GetFieldDistinctValues(ctx context.Context, database, table str
 
 	query := fmt.Sprintf(`
 		SELECT %s AS value, count() AS cnt
-		FROM %s.%s
+		FROM %s
 		PREWHERE %s BETWEEN toDateTime('%s', '%s') AND toDateTime('%s', '%s')
 		WHERE %s%s
 		GROUP BY value ORDER BY cnt DESC LIMIT %d
-	`, quotedField, database, table,
-		params.TimestampField, startTimeStr, timezone, endTimeStr, timezone,
+	`, quotedField, qualifiedTable,
+		quotedTS, startTimeStr, timezone, endTimeStr, timezone,
 		emptyFilter, additionalConditions, limit)
 
 	result, err := c.QueryWithTimeout(ctx, query, timeoutSeconds)
@@ -212,6 +220,8 @@ func extractInt64FromRow(row map[string]any, key string) (int64, bool) {
 
 func (c *Client) queryTotalDistinct(ctx context.Context, database, table string, params FieldValuesParams, startTimeStr, endTimeStr, timezone, additionalConditions string, timeoutSeconds *int) int64 {
 	quotedField := quoteIdentifier(params.FieldName)
+	quotedTS := quoteIdentifier(params.TimestampField)
+	qualifiedTable := fmt.Sprintf("%s.%s", quoteIdentifier(database), quoteIdentifier(table))
 	emptyFilter := fmt.Sprintf("%s != ''", quotedField)
 	if isNumericColumnType(params.FieldType) {
 		emptyFilter = "1"
@@ -219,11 +229,11 @@ func (c *Client) queryTotalDistinct(ctx context.Context, database, table string,
 
 	query := fmt.Sprintf(`
 		SELECT uniq(%s) AS total
-		FROM %s.%s
+		FROM %s
 		PREWHERE %s BETWEEN toDateTime('%s', '%s') AND toDateTime('%s', '%s')
 		WHERE %s%s
-	`, quotedField, database, table,
-		params.TimestampField, startTimeStr, timezone, endTimeStr, timezone,
+	`, quotedField, qualifiedTable,
+		quotedTS, startTimeStr, timezone, endTimeStr, timezone,
 		emptyFilter, additionalConditions)
 
 	result, err := c.QueryWithTimeout(ctx, query, timeoutSeconds)

--- a/internal/datasource/clickhouse_provider.go
+++ b/internal/datasource/clickhouse_provider.go
@@ -671,24 +671,6 @@ func (p *ClickHouseProvider) connectionFromConfig(raw json.RawMessage) (models.C
 }
 
 func (p *ClickHouseProvider) validateColumnTypes(ctx context.Context, client *clickhouse.Client, database, tableName, tsField, severityField string) error {
-	// Validate all identifiers before they are interpolated into SQL.
-	// This is defense-in-depth: callers also validate, but the function guards itself.
-	for _, id := range []struct {
-		field string
-		value string
-	}{
-		{"database", database},
-		{"table", tableName},
-		{"ts_field", tsField},
-	} {
-		if !IsValidIdentifier(id.value) {
-			return &ValidationError{Field: id.field, Message: fmt.Sprintf("invalid identifier %q", id.value)}
-		}
-	}
-	if severityField != "" && !IsValidIdentifier(severityField) {
-		return &ValidationError{Field: "severity_field", Message: fmt.Sprintf("invalid identifier %q", severityField)}
-	}
-
 	tsQuery := fmt.Sprintf(
 		`SELECT type FROM system.columns WHERE database = '%s' AND table = '%s' AND name = '%s'`,
 		database, tableName, tsField,

--- a/internal/datasource/clickhouse_provider.go
+++ b/internal/datasource/clickhouse_provider.go
@@ -671,6 +671,24 @@ func (p *ClickHouseProvider) connectionFromConfig(raw json.RawMessage) (models.C
 }
 
 func (p *ClickHouseProvider) validateColumnTypes(ctx context.Context, client *clickhouse.Client, database, tableName, tsField, severityField string) error {
+	// Validate all identifiers before they are interpolated into SQL.
+	// This is defense-in-depth: callers also validate, but the function guards itself.
+	for _, id := range []struct {
+		field string
+		value string
+	}{
+		{"database", database},
+		{"table", tableName},
+		{"ts_field", tsField},
+	} {
+		if !IsValidIdentifier(id.value) {
+			return &ValidationError{Field: id.field, Message: fmt.Sprintf("invalid identifier %q", id.value)}
+		}
+	}
+	if severityField != "" && !IsValidIdentifier(severityField) {
+		return &ValidationError{Field: "severity_field", Message: fmt.Sprintf("invalid identifier %q", severityField)}
+	}
+
 	tsQuery := fmt.Sprintf(
 		`SELECT type FROM system.columns WHERE database = '%s' AND table = '%s' AND name = '%s'`,
 		database, tableName, tsField,


### PR DESCRIPTION
GetFieldDistinctValues and queryTotalDistinct were interpolating database and table names directly into SQL via fmt.Sprintf without any validation or quoting. stats.go already does this correctly with quoteIdentifier for both - field_values.go was inconsistent. Added ValidateIdentifier checks for database and table, then backtick-quotes all identifiers (database, table, timestamp field) through quoteIdentifier before they reach the query string.

validateColumnTypes in the datasource layer had no guard on its own inputs before interpolating them into single-quoted SQL string values. Added IsValidIdentifier checks for database, table, tsField, and severityField as defense-in-depth so the function is safe regardless of its caller.